### PR TITLE
Add suport for JSExport "delegate to parent" property

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,6 +7,8 @@
 set(SOURCE_Widget
   Widget.hpp
   Widget.cpp
+  ChildWidget.hpp
+  ChildWidget.cpp
 )
 
 set(SOURCE_OtherWidget

--- a/examples/ChildWidget.cpp
+++ b/examples/ChildWidget.cpp
@@ -1,0 +1,46 @@
+/**
+ * HAL
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#include "ChildWidget.hpp"
+
+#include <functional>
+#include <sstream>
+#include <vector>
+
+ChildWidget::ChildWidget(const JSContext& js_context) HAL_NOEXCEPT
+: Widget(js_context) {
+  HAL_LOG_DEBUG("ChildWidget:: ctor ", this);
+}
+
+ChildWidget::~ChildWidget() HAL_NOEXCEPT {
+  HAL_LOG_DEBUG("ChildWidget:: dtor ", this);
+}
+
+void ChildWidget::postInitialize(JSObject& js_object) {
+  HAL_LOG_DEBUG("ChildWidget:: postInitialize ", this);
+}
+
+void ChildWidget::postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) {
+  HAL_LOG_DEBUG("ChildWidget:: postCallAsConstructor ", this);
+}
+
+void ChildWidget::JSExportInitialize() {
+  JSExport<ChildWidget>::SetClassVersion(1);
+  JSExport<ChildWidget>::SetParent(JSExport<Widget>::Class());
+  JSExport<ChildWidget>::AddValueProperty("name", std::mem_fn(&ChildWidget::js_get_name));
+  JSExport<ChildWidget>::AddValueProperty("my_name", std::mem_fn(&ChildWidget::js_get_my_name));
+}
+
+JSValue ChildWidget::js_get_name() const HAL_NOEXCEPT {
+  // delegate to parent
+  return get_context().CreateNativeNull();
+}
+
+JSValue ChildWidget::js_get_my_name() const HAL_NOEXCEPT {
+  return get_context().CreateString("child widget");
+}

--- a/examples/ChildWidget.hpp
+++ b/examples/ChildWidget.hpp
@@ -1,0 +1,53 @@
+/**
+ * HAL
+ *
+ * Copyright (c) 2015 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Apache Public License.
+ * Please see the LICENSE included with this distribution for details.
+ */
+
+#ifndef _HAL_EXAMPLES_CHILDWIDGET_HPP_
+#define _HAL_EXAMPLES_CHILDWIDGET_HPP_
+
+#include "HAL/HAL.hpp"
+#include <string>
+#include "Widget.hpp"
+
+using namespace HAL;
+
+/*!
+ @class
+ 
+ @discussion This is an example of how to create a JavaScript object
+ implemented by a C++ class.
+ */
+class ChildWidget : public Widget, public JSExport<ChildWidget> {
+  
+public:
+  
+  ChildWidget(const JSContext& js_context) HAL_NOEXCEPT;
+  
+  virtual ~ChildWidget()                     HAL_NOEXCEPT;
+  ChildWidget(const ChildWidget&)            HAL_NOEXCEPT = default;
+  ChildWidget(ChildWidget&&)                 HAL_NOEXCEPT = default;
+  ChildWidget& operator=(const ChildWidget&) HAL_NOEXCEPT = default;
+  ChildWidget& operator=(ChildWidget&&)      HAL_NOEXCEPT = default;
+  
+  static void JSExportInitialize();
+  
+  virtual void postInitialize(JSObject& js_object) override;
+  virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
+  
+  JSValue js_get_name() const HAL_NOEXCEPT;
+  JSValue js_get_my_name() const HAL_NOEXCEPT;
+  
+private:
+
+};
+
+inline
+void swap(ChildWidget& first, ChildWidget& second) HAL_NOEXCEPT {
+  first.swap(second);
+}
+
+#endif // _HAL_EXAMPLES_CHILDWIDGET_HPP_

--- a/examples/ChildWidget.hpp
+++ b/examples/ChildWidget.hpp
@@ -26,12 +26,7 @@ class ChildWidget : public Widget, public JSExport<ChildWidget> {
 public:
   
   ChildWidget(const JSContext& js_context) HAL_NOEXCEPT;
-  
-  virtual ~ChildWidget()                     HAL_NOEXCEPT;
-  ChildWidget(const ChildWidget&)            HAL_NOEXCEPT = default;
-  ChildWidget(ChildWidget&&)                 HAL_NOEXCEPT = default;
-  ChildWidget& operator=(const ChildWidget&) HAL_NOEXCEPT = default;
-  ChildWidget& operator=(ChildWidget&&)      HAL_NOEXCEPT = default;
+  virtual ~ChildWidget() HAL_NOEXCEPT;
   
   static void JSExportInitialize();
   

--- a/include/HAL/JSContext.hpp
+++ b/include/HAL/JSContext.hpp
@@ -133,7 +133,16 @@ namespace HAL {
      @result The unique null value.
      */
     JSNull CreateNull() const HAL_NOEXCEPT;
-    
+		
+    /*!
+     @method
+ 
+     @abstract Create a native nullptr. For interoperability with the JavaScriptCore C API.
+ 
+     @result The value which represents native nullptr.
+     */
+    JSValue CreateNativeNull() const HAL_NOEXCEPT;
+		
     /*!
      @method
      

--- a/include/HAL/JSValue.hpp
+++ b/include/HAL/JSValue.hpp
@@ -198,7 +198,17 @@ namespace HAL {
      @result true if this JavaScript value's type is the null type.
      */
     virtual bool IsNull() const HAL_NOEXCEPT final;
-    
+		
+    /*!
+     @method
+     
+     @abstract Determine whether this JavaScript value's type is the
+     null type.
+     
+     @result true if this JavaScript value's type is the null type.
+     */
+    virtual bool IsNativeNull() const HAL_NOEXCEPT final;
+		
     /*!
      @method
      
@@ -290,6 +300,16 @@ namespace HAL {
     virtual JSContext get_context() const HAL_NOEXCEPT final {
       return js_context__;
     }
+
+    /*!
+     @method
+ 
+     @abstract Mark this value as native nullptr. 
+               For interoperability with the JavaScriptCore C API.
+     */
+    virtual void MarkAsNativeNull() HAL_NOEXCEPT final {
+      is_native_nullptr__ = true;
+    }
     
     virtual ~JSValue()           HAL_NOEXCEPT;
     JSValue(const JSValue&)      HAL_NOEXCEPT;
@@ -329,6 +349,9 @@ namespace HAL {
     
     // For interoperability with the JavaScriptCore C API.
     explicit operator JSValueRef() const HAL_NOEXCEPT {
+      if (is_native_nullptr__) {
+        return nullptr;
+      }
       return js_value_ref__;
     }
     
@@ -346,6 +369,8 @@ namespace HAL {
     static void * operator new [] (std::size_t); // #2: To prevent allocation of array of objects
     
     JSContext  js_context__;
+		
+    bool is_native_nullptr__{false};
 
     // Silence 4251 on Windows since private member variables do not
     // need to be exported from a DLL.

--- a/include/HAL/detail/JSExportCallbacks.hpp
+++ b/include/HAL/detail/JSExportCallbacks.hpp
@@ -157,8 +157,8 @@ namespace HAL { namespace detail {
    @abstract The callback to invoke when getting a property's value
    from your JavaScript object.
    
-   @discussion If this callback returns JSUndefined then get request
-   forwards to your JavaScript object's set of
+   @discussion If this callback returns native null value (context.CreateNativeNull())
+   then get request forwards to your JavaScript object's set of
    GetNamedValuePropertyCallback and CallNamedFunctionCallback
    callbacks (if any), then properties vended by your class' parent
    class chain, then properties belonging to your JavaScript object's
@@ -180,7 +180,7 @@ namespace HAL { namespace detail {
    @param 2 A const rvalue reference to the property's name.
    
    @result The property's value with the name given in parameter 2 if
-   it exists. If the property does not exist then return JSUndefined
+   it exists. If the property does not exist then return native null value (context.CreateNativeNull())
    to forward the request to your JavaScript object's set of
    GetNamedValuePropertyCallback and CallNamedFunctionCallback
    callbacks (if any), then properties vended by your class' parent
@@ -371,7 +371,7 @@ namespace HAL { namespace detail {
    @param 2 A JSValue::Type specifying the JavaScript type to convert
    to.
    
-   @result Return the objects's converted value. Return JSUndefined to
+   @result Return the objects's converted value. Return native null value (context.CreateNativeNull())
    forward the reqeust to your class' parent class chain, then your
    JavaScript object's prototype chain.
    */

--- a/src/JSContext.cpp
+++ b/src/JSContext.cpp
@@ -67,7 +67,15 @@ namespace HAL {
     HAL_JSCONTEXT_LOCK_GUARD;
     return JSNull(JSContext(js_global_context_ref__));
   }
-  
+	
+  JSValue JSContext::CreateNativeNull() const HAL_NOEXCEPT {
+    HAL_JSCONTEXT_LOCK_GUARD;
+    // Use JSNull to represent native nullptr
+    auto value = JSNull(JSContext(js_global_context_ref__));
+    value.MarkAsNativeNull();
+    return value;
+  }
+	
   JSBoolean JSContext::CreateBoolean(bool boolean) const HAL_NOEXCEPT {
     HAL_JSCONTEXT_LOCK_GUARD;
     return JSBoolean(JSContext(js_global_context_ref__), boolean);

--- a/src/JSValue.cpp
+++ b/src/JSValue.cpp
@@ -154,7 +154,12 @@ namespace HAL {
     HAL_JSVALUE_LOCK_GUARD;
     return JSValueIsNull(static_cast<JSContextRef>(js_context__), js_value_ref__);
   }
-  
+	
+  bool JSValue::IsNativeNull() const HAL_NOEXCEPT {
+    HAL_JSVALUE_LOCK_GUARD;
+    return is_native_nullptr__;
+  }
+	
   bool JSValue::IsBoolean() const HAL_NOEXCEPT {
     HAL_JSVALUE_LOCK_GUARD;
     return JSValueIsBoolean(static_cast<JSContextRef>(js_context__), js_value_ref__);
@@ -214,7 +219,8 @@ namespace HAL {
   
   JSValue::JSValue(const JSValue& rhs) HAL_NOEXCEPT
   : js_context__(rhs.js_context__)
-  , js_value_ref__(rhs.js_value_ref__) {
+  , js_value_ref__(rhs.js_value_ref__)
+  , is_native_nullptr__(rhs.is_native_nullptr__) {
     HAL_LOG_TRACE("JSValue:: copy ctor ", this);
     HAL_LOG_TRACE("JSValue:: retain ", js_value_ref__, " for ", this);
     JSValueProtect(static_cast<JSContextRef>(js_context__), js_value_ref__);
@@ -222,7 +228,8 @@ namespace HAL {
   
   JSValue::JSValue(JSValue&& rhs) HAL_NOEXCEPT
   : js_context__(std::move(rhs.js_context__))
-  , js_value_ref__(rhs.js_value_ref__) {
+  , js_value_ref__(rhs.js_value_ref__)
+  , is_native_nullptr__(rhs.is_native_nullptr__){
     HAL_LOG_TRACE("JSValue:: move ctor ", this);
     HAL_LOG_TRACE("JSValue:: retain ", js_value_ref__, " for ", this);
     JSValueProtect(static_cast<JSContextRef>(js_context__), js_value_ref__);
@@ -250,6 +257,7 @@ namespace HAL {
     // effectively swapped.
     swap(js_context__  , other.js_context__);
     swap(js_value_ref__, other.js_value_ref__);
+    swap(is_native_nullptr__, other.is_native_nullptr__);
   }
   
   JSValue::JSValue(const JSContext& js_context, const JSString& js_string, bool parse_as_json)
@@ -267,7 +275,7 @@ namespace HAL {
     HAL_LOG_TRACE("JSValue:: retain ", js_value_ref__, " for ", this);
     JSValueProtect(static_cast<JSContextRef>(js_context__), js_value_ref__);
   }
-  
+	
   // For interoperability with the JavaScriptCore C API.
   JSValue::JSValue(const JSContext& js_context, JSValueRef js_value_ref) HAL_NOEXCEPT
   : js_context__(js_context)

--- a/test/JSExportTests.cpp
+++ b/test/JSExportTests.cpp
@@ -8,6 +8,7 @@
 
 #include "HAL/HAL.hpp"
 #include "Widget.hpp"
+#include "ChildWidget.hpp"
 #include "OtherWidget.hpp"
 #include <functional>
 
@@ -146,6 +147,25 @@ TEST_F(JSExportTests, JSExport) {
   // FIXME
   auto string_ptr = widget.GetPrivate<std::string>();
   //XCTAssertEqual(nullptr, string_ptr);
+}
+
+TEST_F(JSExportTests, JSExportPrototypeChain) {
+  JSContext js_context = js_context_group.CreateContext();
+  JSObject global_object = js_context.get_global_object();
+  
+  XCTAssertFalse(global_object.HasProperty("ChildWidget"));
+  JSObject widget = js_context.CreateObject(JSExport<ChildWidget>::Class());
+  global_object.SetProperty("ChildWidget", widget);
+  XCTAssertTrue(global_object.HasProperty("ChildWidget"));
+  
+  // This should return property from parent
+  auto result = js_context.JSEvaluateScript("ChildWidget.name;");
+  XCTAssertTrue(result.IsString());
+  XCTAssertEqual("world", static_cast<std::string>(result));
+
+  result = js_context.JSEvaluateScript("ChildWidget.my_name;");
+  XCTAssertTrue(result.IsString());
+  XCTAssertEqual("child widget", static_cast<std::string>(result));
 }
 
 TEST_F(JSExportTests, JSExportGetPrivate) {

--- a/test/JSObjectTests.cpp
+++ b/test/JSObjectTests.cpp
@@ -38,7 +38,7 @@ TEST_F(JSObjectTests, ObjectSizes) {
   
   // JSValue and JSObject are base classes, so have an extra pointer for the
   // virtual function table.
-  XCTAssertEqual(sizeof(JSContext) + sizeof(std::intptr_t) + sizeof(std::intptr_t), sizeof(JSValue));
+  XCTAssertEqual(sizeof(JSContext) + sizeof(std::intptr_t) + sizeof(std::intptr_t) + sizeof(std::intptr_t), sizeof(JSValue));
   XCTAssertEqual(sizeof(JSContext) + sizeof(std::intptr_t) + sizeof(std::intptr_t), sizeof(JSObject));
 }
 

--- a/test/JSValueTests.cpp
+++ b/test/JSValueTests.cpp
@@ -56,6 +56,19 @@ TEST_F(JSValueTests, JSNull) {
   XCTAssertFalse(js_null.IsObject());
 }
 
+TEST_F(JSValueTests, NativeNull) {
+  JSContext js_context = js_context_group.CreateContext();
+  JSValue js_null = js_context.CreateNativeNull();
+  XCTAssertEqual("null", static_cast<std::string>(js_null));
+  XCTAssertFalse(js_null.IsUndefined());
+  XCTAssertTrue(js_null.IsNull());
+  XCTAssertFalse(js_null.IsBoolean());
+  XCTAssertFalse(js_null.IsNumber());
+  XCTAssertFalse(js_null.IsString());
+  XCTAssertFalse(js_null.IsObject());
+  XCTAssertTrue(js_null.IsNativeNull());
+}
+
 TEST_F(JSValueTests, JSBoolean) {
   JSContext js_context = js_context_group.CreateContext();
   JSBoolean js_false = js_context.CreateBoolean(false);

--- a/xcode/HAL.xcodeproj/project.pbxproj
+++ b/xcode/HAL.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		C9E6AFB61A12FB5300FED053 /* JSLoggerPolicyInterface.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9E6AFB21A12FB5300FED053 /* JSLoggerPolicyInterface.hpp */; };
 		C9E6AFF21A13F97500FED053 /* HAL.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C974543F1A0282FD00CB4CA9 /* HAL.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		F902BA6F1AA9304900B16539 /* OtherWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F902BA6D1AA9304900B16539 /* OtherWidget.cpp */; };
+		F9503D391AD7A63F00D4EA0A /* ChildWidget.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9503D371AD7A63F00D4EA0A /* ChildWidget.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -185,6 +186,8 @@
 		C9E6AFB21A12FB5300FED053 /* JSLoggerPolicyInterface.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = JSLoggerPolicyInterface.hpp; path = include/HAL/detail/JSLoggerPolicyInterface.hpp; sourceTree = "<group>"; };
 		F902BA6D1AA9304900B16539 /* OtherWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OtherWidget.cpp; path = ../../examples/OtherWidget.cpp; sourceTree = "<group>"; };
 		F902BA6E1AA9304900B16539 /* OtherWidget.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = OtherWidget.hpp; path = ../../examples/OtherWidget.hpp; sourceTree = "<group>"; };
+		F9503D371AD7A63F00D4EA0A /* ChildWidget.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ChildWidget.cpp; path = ../../examples/ChildWidget.cpp; sourceTree = "<group>"; };
+		F9503D381AD7A63F00D4EA0A /* ChildWidget.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = ChildWidget.hpp; path = ../../examples/ChildWidget.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -256,6 +259,8 @@
 				C974542C1A0280A400CB4CA9 /* JSExportTests.mm */,
 				C97454ED1A0B66E500CB4CA9 /* Widget.hpp */,
 				C985CB081A107E96004D4163 /* Widget.cpp */,
+				F9503D371AD7A63F00D4EA0A /* ChildWidget.cpp */,
+				F9503D381AD7A63F00D4EA0A /* ChildWidget.hpp */,
 				F902BA6D1AA9304900B16539 /* OtherWidget.cpp */,
 				F902BA6E1AA9304900B16539 /* OtherWidget.hpp */,
 				C974548B1A05FC5D00CB4CA9 /* JSLoggerTests.mm */,
@@ -603,6 +608,7 @@
 				C985CB091A107E96004D4163 /* Widget.cpp in Sources */,
 				C974543D1A02810600CB4CA9 /* LambdaTests.mm in Sources */,
 				C97454311A0280A400CB4CA9 /* JSContextGroupTests.mm in Sources */,
+				F9503D391AD7A63F00D4EA0A /* ChildWidget.cpp in Sources */,
 				C97454371A0280A400CB4CA9 /* HashUtilitiesTests.mm in Sources */,
 				C97454341A0280A400CB4CA9 /* JSObjectTests.mm in Sources */,
 				C97454361A0280A400CB4CA9 /* JSValueTests.mm in Sources */,

--- a/xcode/HALTests/JSExportTests.mm
+++ b/xcode/HALTests/JSExportTests.mm
@@ -8,6 +8,7 @@
 
 #include "HAL/HAL.hpp"
 #include "Widget.hpp"
+#include "ChildWidget.hpp"
 #include "OtherWidget.hpp"
 #include <typeinfo>
 #include <iostream>
@@ -160,6 +161,26 @@ using namespace HAL;
 	// FIXME
 	auto string_ptr = widget.GetPrivate<std::string>();
 	//XCTAssertEqual(nullptr, string_ptr);
+}
+
+- (void)testJSExportPrototypeChain
+{
+	JSContext js_context = js_context_group.CreateContext();
+	JSObject global_object = js_context.get_global_object();
+	
+	XCTAssertFalse(global_object.HasProperty("ChildWidget"));
+	JSObject widget = js_context.CreateObject(JSExport<ChildWidget>::Class());
+	global_object.SetProperty("ChildWidget", widget);
+	XCTAssertTrue(global_object.HasProperty("ChildWidget"));
+	
+	// This should return property from parent
+	auto result = js_context.JSEvaluateScript("ChildWidget.name;");
+	XCTAssertTrue(result.IsString());
+	XCTAssertEqual("world", static_cast<std::string>(result));
+
+	result = js_context.JSEvaluateScript("ChildWidget.my_name;");
+	XCTAssertTrue(result.IsString());
+	XCTAssertEqual("child widget", static_cast<std::string>(result));
 }
 
 - (void)testJSExportGetPrivate

--- a/xcode/HALTests/JSObjectTests.mm
+++ b/xcode/HALTests/JSObjectTests.mm
@@ -41,7 +41,7 @@ namespace UnitTestConstants {
   
   // JSValue and JSObject are base classes, so have an extra pointer for the
   // virtual function table.
-  XCTAssertEqual(sizeof(JSContext) + sizeof(std::intptr_t) + sizeof(std::intptr_t), sizeof(JSValue));
+  XCTAssertEqual(sizeof(JSContext) + sizeof(std::intptr_t) + sizeof(std::intptr_t) + sizeof(std::intptr_t), sizeof(JSValue));
   XCTAssertEqual(sizeof(JSContext) + sizeof(std::intptr_t) + sizeof(std::intptr_t), sizeof(JSObject));
 }
 

--- a/xcode/HALTests/JSValueTests.mm
+++ b/xcode/HALTests/JSValueTests.mm
@@ -56,6 +56,19 @@ namespace UnitTestConstants {
   XCTAssertFalse(js_null.IsObject());
 }
 
+- (void)testNativeNull {
+  JSContext js_context = js_context_group.CreateContext();
+  JSValue js_null = js_context.CreateNativeNull();
+  XCTAssertEqual("null", static_cast<std::string>(js_null));
+  XCTAssertFalse(js_null.IsUndefined());
+  XCTAssertTrue(js_null.IsNull());
+  XCTAssertFalse(js_null.IsBoolean());
+  XCTAssertFalse(js_null.IsNumber());
+  XCTAssertFalse(js_null.IsString());
+  XCTAssertFalse(js_null.IsObject());
+  XCTAssertTrue(js_null.IsNativeNull());
+}
+
 - (void)testJSBoolean {
   JSContext js_context = js_context_group.CreateContext();
   JSBoolean js_false = js_context.CreateBoolean(false);


### PR DESCRIPTION
Related to #42. JSExport class should have had a way to forward property request to prototype chain. Added `CreateNativeNull()` so that you can mark it as "delegate to parent". 

```c++
JSValue GlobalObject::getXXXProperty(const JSString& property_name) const
{
      if (property_name == "i_want_null") {
        return get_context().CreateNull();
      } else if (property_name == "i_want_undefined") {
        return get_context().CreateUndefined();
      } else if (property_name == "i_want_prototype_chain") {
        return get_context().CreateNativeNull();
      }
...
}
```