### PR TITLE
Add build script for iOS static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,24 @@ option(HAL_DISABLE_TESTS "Disable compiling the tests" OFF)
 # Define helper functions and macros.
 include(${PROJECT_SOURCE_DIR}/cmake/internal_utils.cmake)
 
+# Target architecture, only available for iOS
+set(ARCH "i386" CACHE STRING "Target Architecture")
+
+# Target platform, only available on Xcode
+# "macosx", "iphoneos" or "iphonesimulator"
+set(PLATFORM "macosx" CACHE STRING "Target Platform")
+
+# Build shared library by default
+set(LIBRARY_BUILD_TYPE SHARED)
+
 # Defined in internal_utils.cmake.
 config_compiler_and_linker()
-#config_cmake_system_framework_path(macosx)
+
+# Prepare SDK configuration for iOS
+if (NOT WIN32 AND ${PLATFORM} STREQUAL "iphoneos" OR ${PLATFORM} STREQUAL "iphonesimulator")
+  set(LIBRARY_BUILD_TYPE STATIC)
+  config_cmake_system_framework_path(${PLATFORM})
+endif()
 
 # Allow "make test" to work.
 enable_testing()
@@ -140,7 +155,7 @@ source_group(HAL\\JSLogger\\detail FILES ${SOURCE_JSLogger_detail})
 #set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 #set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
-add_library(HAL SHARED
+add_library(HAL ${LIBRARY_BUILD_TYPE}
   ${SOURCE_HAL}
   ${SOURCE_HAL_detail}
   ${SOURCE_JSExport}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ $ curl -O http://timobile.appcelerator.com.s3.amazonaws.com/gtest-1.7.0-osx.zip
 $ unzip gtest-1.7.0-osx.zip
 ```
 
+### iOS
+
+Step 1. Make sure you have all prerequisites described above.
+
 ### Windows
 
 Step 1. Install Visual Studio 2013
@@ -61,6 +65,12 @@ To run our unit tests on both both OS X and Windows:
 
 ```bash
 build_and_test.sh
+```
+
+To build static library for iOS simulator, run following command. Note that this builds iOS static library for iPhone simulator by default. If you need a static library for the device, edit `build_ios.sh` and change ARCH and PLATFORM variables.
+
+```bash
+build_ios.sh
 ```
 
 Here is [EvaluateScript.cpp](examples/EvaluateScript.cpp), a simple main program that evaluates the JavaScript expression `21 / 7` and prints `3` to the terminal. To run it on Windows type `./build.debug/examples/EvaluateScript.exe` and to run it on OS X type `./build.debug/examples/EvaluateScript`.

--- a/build_ios.sh
+++ b/build_ios.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# HAL
+#
+# Copyright (c) 2014 by Appcelerator, Inc. All Rights Reserved.
+# Licensed under the terms of the Apache Public License.
+# Please see the LICENSE included with this distribution for details.
+
+set -e
+
+declare -rx VERBOSE=1
+declare -r HAL_DISABLE_TESTS="ON"
+
+cmd+="cmake"
+cmd+=" -DHAL_DISABLE_TESTS=${HAL_DISABLE_TESTS}"
+cmd+=" -DARCH=i386 -DPLATFORM=iphonesimulator"
+#cmd+=" -DARCH=arm64 -DPLATFORM=iphoneos"
+
+declare -r CMAKE_BUILD_TYPE=Debug
+declare -r BUILD_DIR=build.$(echo ${CMAKE_BUILD_TYPE} | tr '[:upper:]' '[:lower:]')
+cmd+=" -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+cmd+=" ../"
+cmd+=" && make -j 4"
+
+function echo_and_eval {
+    local -r cmd="${1:?}"
+    echo "${cmd}" && eval "${cmd}"
+}
+
+echo_and_eval "rm -rf \"${BUILD_DIR}\""
+echo_and_eval "mkdir -p \"${BUILD_DIR}\""
+echo_and_eval "pushd \"${BUILD_DIR}\""
+echo_and_eval "${cmd}"
+
+echo_and_eval "popd"

--- a/cmake/internal_utils_xcode.cmake
+++ b/cmake/internal_utils_xcode.cmake
@@ -84,6 +84,7 @@ function(find_xcode_framework_dirs VAR sdk)
   set(XCODE_FRAMEWORK_DIRS "${XCODE_SDKROOT}/System/Library/Frameworks" "${XCODE_DEVELOPER_DIR}/Library/Frameworks")
   list(REMOVE_DUPLICATES XCODE_FRAMEWORK_DIRS)
   set("${VAR}" ${XCODE_FRAMEWORK_DIRS} PARENT_SCOPE)
+  set(XCODE_SDKROOT ${XCODE_SDKROOT} PARENT_SCOPE)
 endfunction()
 
 # Prepend the user-selected Xcode SDK framework directories (via
@@ -101,6 +102,9 @@ function(config_cmake_system_framework_path sdk)
   list(REMOVE_DUPLICATES CMAKE_SYSTEM_FRAMEWORK_PATH)
   # Make sure our caller can see the changes.
   set(CMAKE_SYSTEM_FRAMEWORK_PATH ${CMAKE_SYSTEM_FRAMEWORK_PATH} PARENT_SCOPE)
+  if ("${sdk}" MATCHES "iphoneos" OR "${sdk}" MATCHES "iphonesimulator")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -arch ${ARCH} -isysroot ${XCODE_SDKROOT} -I${XCODE_SDKROOT}/usr/include" PARENT_SCOPE)
+  endif()
 endfunction()
 
 # ocunit_test(name libs srcs...)


### PR DESCRIPTION
Added build script for iOS static library for both simulator and device.

```bash
$ cd YOUR_HAL_DIR
$ ./build_ios.sh
$ ls -la build.debug/libHAL.a 
```

`build_ios.sh` builds iOS static library for iPhone simulator by default. If you need a static library for the device, edit `build_ios.sh` and change `ARCH` and `PLATFORM` variables.

```bash
#cmd+=" -DARCH=i386 -DPLATFORM=iphonesimulator"
cmd+=" -DARCH=arm64 -DPLATFORM=iphoneos"
```
