### PR TITLE
[TIMOB-18855] Fix: new Date() returns wrong value

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Step 3. Install [64-bit Cygwin](http://cygwin.com/setup-x86_64.exe).
 
 Step 4. Install JavascriptCore
 
-Download our pre-compiled version of JavascriptCore [JavaScriptCore-Windows-1411436814.zip (276 MB)](http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1411436814.zip), unzip anywhere (the location doesn't matter) and set the environment variable JavaScriptCore_HOME to where you unzipped it.
+Download our pre-compiled version of JavascriptCore [JavaScriptCore-Windows-1430359270.zip (428 MB)](http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1430359270.zip), unzip anywhere (the location doesn't matter) and set the environment variable JavaScriptCore_HOME to where you unzipped it.
 
 Just run the following commands from your Cygwin bash prompt to setup your development environment for JavaScriptCore_HOME before
 proceeding:
 
 ```bash
-$ curl -O http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1411436814.zip
-$ unzip JavaScriptCore-Windows-1411436814.zip
+$ curl -O http://timobile.appcelerator.com.s3.amazonaws.com/jscore/JavaScriptCore-Windows-1430359270.zip
+$ unzip JavaScriptCore-Windows-1430359270.zip
 ```
 
 step 5. Install Google Test

--- a/test/JSContextTests.cpp
+++ b/test/JSContextTests.cpp
@@ -9,6 +9,8 @@
 #include "HAL/HAL.hpp"
 
 #include "gtest/gtest.h"
+#include <chrono>
+#include <thread>
 
 #define XCTAssertEqual    ASSERT_EQ
 #define XCTAssertNotEqual ASSERT_NE
@@ -32,6 +34,17 @@ TEST_F(JSContextTests, JSEvaluateScript) {
   JSContext js_context = js_context_group.CreateContext();
   JSValue js_value     = js_context.JSEvaluateScript("'Hello, world.'");
   XCTAssertEqual("Hello, world.", static_cast<std::string>(js_value));
+}
+
+TEST_F(JSContextTests, TIMOB_18855) {
+  JSContext js_context = js_context_group.CreateContext();
+  js_context.JSEvaluateScript("var start=new Date().getTime();");
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  JSValue js_value = js_context.JSEvaluateScript("new Date().getTime() - start;");
+  XCTAssertFalse(static_cast<std::int32_t>(js_value) == 1);
+  XCTAssertTrue(static_cast<std::int32_t>(js_value) >  999);
+  // assuming JS evaluation is done within 500 msec...
+  XCTAssertTrue(static_cast<std::int32_t>(js_value) < 1500);
 }
 
 TEST_F(JSContextTests, JSEvaluateScriptWithError) {


### PR DESCRIPTION
It was originally because JavaScriptCore returns wrong value for `new Date()` so we just need to upgrade the library.