### PR TITLE
Shorthand for creating a JS function with a given native callback

### DIFF
--- a/include/HAL/JSArray.hpp
+++ b/include/HAL/JSArray.hpp
@@ -35,7 +35,52 @@ public:
      @result An array of JSValue with the result of conversion.
      */
     virtual operator std::vector<JSValue>() const final;
-	
+
+    /*!
+     @method
+     
+     @abstract Convert this JSArray to a std::vector<bool>
+     
+     @result An array of bool with the result of conversion.
+     */
+    virtual operator std::vector<bool>() const final;
+
+    /*!
+     @method
+     
+     @abstract Convert this JSArray to a std::vector<std::string>
+     
+     @result An array of std::string with the result of conversion.
+     */
+    virtual operator std::vector<std::string>() const final;
+
+    /*!
+     @method
+     
+     @abstract Convert this JSArray to a std::vector<double>
+     
+     @result An array of double with the result of conversion.
+     */
+    virtual operator std::vector<double>() const final;
+
+    /*!
+     @method
+     
+     @abstract Convert this JSArray to a std::vector<int32_t>
+     
+     @result An array of int32_t with the result of conversion.
+     */
+    virtual operator std::vector<int32_t>() const final;
+
+    /*!
+     @method
+     
+     @abstract Convert this JSArray to a std::vector<uint32_t>
+     
+     @result An array of uint32_t with the result of conversion.
+     */
+    virtual operator std::vector<uint32_t>() const final;
+
     /*!
      @method
      

--- a/include/HAL/JSArray.hpp
+++ b/include/HAL/JSArray.hpp
@@ -85,6 +85,8 @@ public:
      @method
      
      @abstract Return length of this JSArray
+     The length is converted to an uint32_t according to
+     the rules specified in ECMA-262 15.4.
      
      @result Length of this JSArray
      */

--- a/include/HAL/JSContext.hpp
+++ b/include/HAL/JSContext.hpp
@@ -315,8 +315,34 @@ namespace HAL {
     JSFunction CreateFunction(const JSString& body, const std::vector<JSString>& parameter_names, const JSString& function_name) const;
     JSFunction CreateFunction(const JSString& body, const std::vector<JSString>& parameter_names, const JSString& function_name, const JSString& source_url, int starting_line_number = 1) const;
 
+    /*!
+     @method
+     
+     @abstract Create a JavaScript function with a given callback
+     as its implementation by C++11 lambda/std::function.
+
+     @param callback A C++11 function to invoke when the function is called
+     k
+     @param function_name An optional JSString containing the
+     function's name. This will be used when converting the function
+     to a string. An empty string creates an anonymous function.
+
+     @result A JSObject that is a function. The object's prototype
+     will be the default function prototype.
+     */
     JSFunction CreateFunction(JSFunctionCallback& callback) const;
     JSFunction CreateFunction(const JSString& function_name, JSFunctionCallback& callback) const;
+
+    /*!
+     @method
+     
+     @abstract Create a JavaScript function which does basically nothing.
+     This is useful when you need a JSFunction as class member which does nothing by default.
+
+     @result A JSObject that is a function. The object's prototype
+     will be the default function prototype.
+     */
+    JSFunction CreateFunction() const;
     
     /* Script Evaluation */
     

--- a/include/HAL/JSContext.hpp
+++ b/include/HAL/JSContext.hpp
@@ -40,6 +40,8 @@ namespace HAL {
   }}
 
 namespace HAL {
+
+  typedef std::function<JSValue(const std::vector<JSValue>, JSObject&)> JSFunctionCallback;
   
   /*!
    @class
@@ -312,7 +314,9 @@ namespace HAL {
     JSFunction CreateFunction(const JSString& body, const std::vector<JSString>& parameter_names) const;
     JSFunction CreateFunction(const JSString& body, const std::vector<JSString>& parameter_names, const JSString& function_name) const;
     JSFunction CreateFunction(const JSString& body, const std::vector<JSString>& parameter_names, const JSString& function_name, const JSString& source_url, int starting_line_number = 1) const;
-    
+
+    JSFunction CreateFunction(JSFunctionCallback& callback) const;
+    JSFunction CreateFunction(const JSString& function_name, JSFunctionCallback& callback) const;
     
     /* Script Evaluation */
     

--- a/include/HAL/JSFunction.hpp
+++ b/include/HAL/JSFunction.hpp
@@ -10,9 +10,12 @@
 #define _HAL_JSFUNCTION_HPP_
 
 #include "HAL/JSObject.hpp"
+#include <functional>
+#include <unordered_map>
 
 namespace HAL {
 
+    
 /*!
   @class
   
@@ -25,15 +28,35 @@ namespace HAL {
   JSContext::CreateFunction member function.
 */
 class HAL_EXPORT JSFunction final : public JSObject HAL_PERFORMANCE_COUNTER2(JSFunction) {
-	
- private:
-	
-	// Only a JSContext can create a JSFunction.
-	friend JSContext;
-	
-	JSFunction(const JSContext& js_context, const JSString& body, const std::vector<JSString>& parameter_names, const JSString& function_name, const JSString& source_url, int starting_line_number);
 
-	static JSObjectRef MakeFunction(const JSContext& js_context, const JSString& body, const std::vector<JSString>& parameter_names, const JSString& function_name, const JSString& source_url, int starting_line_number);
+public:
+    
+    static void RegisterJSFunctionCallback(JSObjectRef js_object_ref, JSFunctionCallback);
+    static void UnRegisterJSFunctionCallback(JSObjectRef js_object_ref);
+    static JSFunctionCallback FindJSFunctionCallback(JSObjectRef js_object_ref);
+
+    virtual ~JSFunction() HAL_NOEXCEPT;
+
+private:
+    
+    // Only a JSContext can create a JSFunction.
+    friend JSContext;
+    
+    JSFunction(const JSContext& js_context, const JSString& body, const std::vector<JSString>& parameter_names, const JSString& function_name, const JSString& source_url, int starting_line_number);
+    JSFunction(const JSContext& js_context, const JSString& function_name, const JSFunctionCallback& callback);
+
+    static JSObjectRef MakeFunction(const JSContext& js_context, const JSString& body, const std::vector<JSString>& parameter_names, const JSString& function_name, const JSString& source_url, int starting_line_number);
+
+    static JSValueRef  JSObjectCallAsFunctionCallback(JSContextRef context_ref, JSObjectRef function_ref, JSObjectRef this_object_ref, size_t argument_count, const JSValueRef arguments_array[], JSValueRef* exception);
+    static JSObjectRef MakeFunction(const JSContext& js_context, const JSString& function_name, const JSFunctionCallback& callback);
+
+    // Silence 4251 on Windows since private member variables do not
+    // need to be exported from a DLL.
+#pragma warning(push)
+#pragma warning(disable: 4251)
+    static std::unordered_map<std::intptr_t, JSFunctionCallback> js_object_ref_to_js_function__;
+#pragma warning(pop)
+
 };
 
 } // namespace HAL {

--- a/include/HAL/JSObject.hpp
+++ b/include/HAL/JSObject.hpp
@@ -354,6 +354,7 @@ namespace HAL {
     // access to the following JSObject constructor.
     
     friend class JSValue;
+    friend class JSFunction;
     
     // The JSExportClass static functions also need access to
     // GetPrivate and SetPrivate.
@@ -370,8 +371,6 @@ namespace HAL {
     explicit operator JSObjectRef() const HAL_NOEXCEPT {
       return js_object_ref__;
     }
-    
-  private:
     
     /*!
      @method

--- a/src/JSArray.cpp
+++ b/src/JSArray.cpp
@@ -65,4 +65,50 @@ JSArray::operator std::vector<JSValue>() const {
 	return items;
 }
 
+JSArray::operator std::vector<bool>() const {
+	std::vector<bool> items;
+	const auto length = GetLength();
+	for (uint32_t i = 0; i < length; i++) {
+		items.push_back(static_cast<bool>(GetProperty(i)));
+	}
+	return items;
+}
+
+JSArray::operator std::vector<std::string>() const {
+	std::vector<std::string> items;
+	const auto length = GetLength();
+	for (uint32_t i = 0; i < length; i++) {
+		items.push_back(static_cast<std::string>(GetProperty(i)));
+	}
+	return items;
+}
+
+JSArray::operator std::vector<double>() const {
+	std::vector<double> items;
+	const auto length = GetLength();
+	for (uint32_t i = 0; i < length; i++) {
+		items.push_back(static_cast<double>(GetProperty(i)));
+	}
+	return items;
+}
+
+JSArray::operator std::vector<int32_t>() const {
+	std::vector<int32_t> items;
+	const auto length = GetLength();
+	for (uint32_t i = 0; i < length; i++) {
+		items.push_back(static_cast<int32_t>(GetProperty(i)));
+	}
+	return items;
+}
+
+JSArray::operator std::vector<uint32_t>() const {
+	std::vector<uint32_t> items;
+	const auto length = GetLength();
+	for (uint32_t i = 0; i < length; i++) {
+		items.push_back(static_cast<uint32_t>(GetProperty(i)));
+	}
+	return items;
+}
+
+
 } // namespace HAL {

--- a/src/JSArray.cpp
+++ b/src/JSArray.cpp
@@ -57,8 +57,9 @@ uint32_t JSArray::GetLength() const HAL_NOEXCEPT {
 }
 
 JSArray::operator std::vector<JSValue>() const {
-	std::vector<JSValue> items;
 	const auto length = GetLength();
+	std::vector<JSValue> items;
+	items.reserve(length);
 	for (uint32_t i = 0; i < length; i++) {
 		items.push_back(GetProperty(i));
 	}
@@ -66,8 +67,9 @@ JSArray::operator std::vector<JSValue>() const {
 }
 
 JSArray::operator std::vector<bool>() const {
-	std::vector<bool> items;
 	const auto length = GetLength();
+	std::vector<bool> items;
+	items.reserve(length);
 	for (uint32_t i = 0; i < length; i++) {
 		items.push_back(static_cast<bool>(GetProperty(i)));
 	}
@@ -75,8 +77,9 @@ JSArray::operator std::vector<bool>() const {
 }
 
 JSArray::operator std::vector<std::string>() const {
-	std::vector<std::string> items;
 	const auto length = GetLength();
+	std::vector<std::string> items;
+	items.reserve(length);
 	for (uint32_t i = 0; i < length; i++) {
 		items.push_back(static_cast<std::string>(GetProperty(i)));
 	}
@@ -84,8 +87,9 @@ JSArray::operator std::vector<std::string>() const {
 }
 
 JSArray::operator std::vector<double>() const {
-	std::vector<double> items;
 	const auto length = GetLength();
+	std::vector<double> items;
+	items.reserve(length);
 	for (uint32_t i = 0; i < length; i++) {
 		items.push_back(static_cast<double>(GetProperty(i)));
 	}
@@ -93,8 +97,9 @@ JSArray::operator std::vector<double>() const {
 }
 
 JSArray::operator std::vector<int32_t>() const {
-	std::vector<int32_t> items;
 	const auto length = GetLength();
+	std::vector<int32_t> items;
+	items.reserve(length);
 	for (uint32_t i = 0; i < length; i++) {
 		items.push_back(static_cast<int32_t>(GetProperty(i)));
 	}
@@ -102,8 +107,9 @@ JSArray::operator std::vector<int32_t>() const {
 }
 
 JSArray::operator std::vector<uint32_t>() const {
-	std::vector<uint32_t> items;
 	const auto length = GetLength();
+	std::vector<uint32_t> items;
+	items.reserve(length);
 	for (uint32_t i = 0; i < length; i++) {
 		items.push_back(static_cast<uint32_t>(GetProperty(i)));
 	}

--- a/src/JSContext.cpp
+++ b/src/JSContext.cpp
@@ -175,6 +175,15 @@ namespace HAL {
     HAL_JSCONTEXT_LOCK_GUARD;
     return JSFunction(JSContext(js_global_context_ref__), body, parameter_names, function_name, source_url, starting_line_number);
   }
+
+  JSFunction JSContext::CreateFunction(JSFunctionCallback& callback) const {
+    return CreateFunction(JSString(), callback);
+  }
+
+  JSFunction JSContext::CreateFunction(const JSString& function_name, JSFunctionCallback& callback) const {
+    HAL_JSCONTEXT_LOCK_GUARD;
+    return JSFunction(JSContext(js_global_context_ref__), function_name, callback);
+  }
   
   JSValue JSContext::JSEvaluateScript(const JSString& script) const {
     return JSEvaluateScript(script, get_global_object(), JSString());

--- a/src/JSContext.cpp
+++ b/src/JSContext.cpp
@@ -176,6 +176,11 @@ namespace HAL {
     return JSFunction(JSContext(js_global_context_ref__), body, parameter_names, function_name, source_url, starting_line_number);
   }
 
+  JSFunction JSContext::CreateFunction() const {
+    JSFunctionCallback noop = [](const std::vector<JSValue>, JSObject& this_object){ return this_object.get_context().CreateUndefined(); };
+    return CreateFunction(noop);
+  }
+
   JSFunction JSContext::CreateFunction(JSFunctionCallback& callback) const {
     return CreateFunction(JSString(), callback);
   }

--- a/src/JSFunction.cpp
+++ b/src/JSFunction.cpp
@@ -9,6 +9,7 @@
 #include "HAL/JSFunction.hpp"
 #include "HAL/JSString.hpp"
 #include "HAL/JSValue.hpp"
+#include "HAL/JSUndefined.hpp"
 #include "HAL/detail/JSUtil.hpp"
 #include <vector>
 #include <algorithm>
@@ -18,28 +19,99 @@
 namespace HAL {
 
 JSFunction::JSFunction(const JSContext& js_context, const JSString& body, const std::vector<JSString>& parameter_names, const JSString& function_name, const JSString& source_url, int starting_line_number)
-		: JSObject(js_context, MakeFunction(js_context, body, parameter_names, function_name, source_url, starting_line_number)) {
+        : JSObject(js_context, MakeFunction(js_context, body, parameter_names, function_name, source_url, starting_line_number)) {
+}
+
+JSFunction::JSFunction(const JSContext& js_context, const JSString& function_name, const JSFunctionCallback& callback)
+        : JSObject(js_context, MakeFunction(js_context, function_name, callback)) {
 }
 
 JSObjectRef JSFunction::MakeFunction(const JSContext& js_context, const JSString& body, const std::vector<JSString>& parameter_names, const JSString& function_name, const JSString& source_url, int starting_line_number) {
-	JSValueRef exception { nullptr };
-	JSStringRef source_url_ref = (source_url.length() > 0) ? static_cast<JSStringRef>(source_url) : nullptr;
-	JSObjectRef js_object_ref = nullptr;
-	if (!parameter_names.empty()) {
-		std::vector<JSStringRef> parameter_name_array = detail::to_vector(parameter_names);
-		js_object_ref = JSObjectMakeFunction(static_cast<JSContextRef>(js_context), static_cast<JSStringRef>(function_name), static_cast<unsigned>(parameter_name_array.size()), &parameter_name_array[0], static_cast<JSStringRef>(body), source_url_ref, starting_line_number, &exception);
-	} else {
-		js_object_ref = JSObjectMakeFunction(static_cast<JSContextRef>(js_context), static_cast<JSStringRef>(function_name), 0, nullptr, static_cast<JSStringRef>(body), source_url_ref, starting_line_number, &exception);
-	}
-	
-	if (exception) {
-		// If this assert fails then we need to JSValueUnprotect
-		// js_object_ref.
-		assert(!js_object_ref);
-		detail::ThrowRuntimeError("JSFunction", JSValue(js_context, exception));
-	}
+    JSValueRef exception { nullptr };
+    JSStringRef source_url_ref = (source_url.length() > 0) ? static_cast<JSStringRef>(source_url) : nullptr;
+    JSObjectRef js_object_ref = nullptr;
+    if (!parameter_names.empty()) {
+        std::vector<JSStringRef> parameter_name_array = detail::to_vector(parameter_names);
+        js_object_ref = JSObjectMakeFunction(static_cast<JSContextRef>(js_context), static_cast<JSStringRef>(function_name), static_cast<unsigned>(parameter_name_array.size()), &parameter_name_array[0], static_cast<JSStringRef>(body), source_url_ref, starting_line_number, &exception);
+    } else {
+        js_object_ref = JSObjectMakeFunction(static_cast<JSContextRef>(js_context), static_cast<JSStringRef>(function_name), 0, nullptr, static_cast<JSStringRef>(body), source_url_ref, starting_line_number, &exception);
+    }
+    
+    if (exception) {
+        // If this assert fails then we need to JSValueUnprotect
+        // js_object_ref.
+        assert(!js_object_ref);
+        detail::ThrowRuntimeError("JSFunction", JSValue(js_context, exception));
+    }
 
-	return js_object_ref;
+    return js_object_ref;
 }
 
+std::unordered_map<std::intptr_t, JSFunctionCallback> JSFunction::js_object_ref_to_js_function__;
+
+void JSFunction::RegisterJSFunctionCallback(JSObjectRef js_object_ref, JSFunctionCallback callback) {
+    HAL_JSOBJECT_LOCK_GUARD_STATIC;
+    const auto key   = reinterpret_cast<std::intptr_t>(js_object_ref);
+    const auto value = callback;
+    const auto position = js_object_ref_to_js_function__.find(key);
+    const bool found    = position != js_object_ref_to_js_function__.end();
+    
+    if (found) {
+      HAL_LOG_DEBUG("JSFunction::RegisterJSFunctionCallback: JSObjectRef ", js_object_ref, " already registered");
+    } else {
+      const auto insert_result = js_object_ref_to_js_function__.emplace(key, value);
+      const bool inserted      = insert_result.second;
+      
+      assert(inserted);
+    }
+}
+
+void JSFunction::UnRegisterJSFunctionCallback(JSObjectRef js_object_ref) {
+    HAL_JSOBJECT_LOCK_GUARD_STATIC;
+    const auto key      = reinterpret_cast<std::intptr_t>(js_object_ref);
+    const auto position = js_object_ref_to_js_function__.find(key);
+    const bool found    = position != js_object_ref_to_js_function__.end();
+    
+    if (found) {
+        js_object_ref_to_js_function__.erase(key);
+    }
+}
+
+JSFunctionCallback JSFunction::FindJSFunctionCallback(JSObjectRef js_object_ref) {
+    HAL_JSOBJECT_LOCK_GUARD_STATIC;
+    const auto key      = reinterpret_cast<std::intptr_t>(js_object_ref);
+    const auto position = js_object_ref_to_js_function__.find(key);
+    const bool found    = position != js_object_ref_to_js_function__.end();
+    
+    if (found) {
+      return position->second;
+    } else {
+        return nullptr;
+    }
+}
+
+JSValueRef JSFunction::JSObjectCallAsFunctionCallback(JSContextRef context_ref, JSObjectRef function_ref, JSObjectRef this_object_ref, size_t argument_count, const JSValueRef arguments_array[], JSValueRef* exception) {
+    const auto callback = FindJSFunctionCallback(function_ref);
+    if (callback == nullptr) {
+        return JSValueMakeUndefined(context_ref);
+    }
+    const auto ctx = JSContext(context_ref);
+    std::vector<JSValue> arguments;
+    for (size_t i = 0; i < argument_count; i++) {
+        arguments.push_back(JSValue(ctx, arguments_array[i]));
+    }
+    auto this_object = JSObject(ctx, this_object_ref);
+    return static_cast<JSValueRef>(callback(arguments, this_object));
+}
+
+JSObjectRef JSFunction::MakeFunction(const JSContext& js_context, const JSString& function_name, const JSFunctionCallback& callback) {
+    JSObjectRef js_object_ref = JSObjectMakeFunctionWithCallback(static_cast<JSContextRef>(js_context), static_cast<JSStringRef>(function_name), JSFunction::JSObjectCallAsFunctionCallback);
+    JSFunction::RegisterJSFunctionCallback(js_object_ref, callback);
+    return js_object_ref;
+}
+
+JSFunction::~JSFunction() HAL_NOEXCEPT {
+    JSFunction::UnRegisterJSFunctionCallback(js_object_ref__);
+}
+    
 } // namespace HAL {

--- a/src/JSFunction.cpp
+++ b/src/JSFunction.cpp
@@ -97,6 +97,7 @@ JSValueRef JSFunction::JSObjectCallAsFunctionCallback(JSContextRef context_ref, 
     }
     const auto ctx = JSContext(context_ref);
     std::vector<JSValue> arguments;
+    arguments.reserve(argument_count);
     for (size_t i = 0; i < argument_count; i++) {
         arguments.push_back(JSValue(ctx, arguments_array[i]));
     }

--- a/src/JSFunction.cpp
+++ b/src/JSFunction.cpp
@@ -68,13 +68,8 @@ void JSFunction::RegisterJSFunctionCallback(JSObjectRef js_object_ref, JSFunctio
 
 void JSFunction::UnRegisterJSFunctionCallback(JSObjectRef js_object_ref) {
     HAL_JSOBJECT_LOCK_GUARD_STATIC;
-    const auto key      = reinterpret_cast<std::intptr_t>(js_object_ref);
-    const auto position = js_object_ref_to_js_function__.find(key);
-    const bool found    = position != js_object_ref_to_js_function__.end();
-    
-    if (found) {
-        js_object_ref_to_js_function__.erase(key);
-    }
+    const auto key = reinterpret_cast<std::intptr_t>(js_object_ref);
+    js_object_ref_to_js_function__.erase(key);
 }
 
 JSFunctionCallback JSFunction::FindJSFunctionCallback(JSObjectRef js_object_ref) {

--- a/test/JSObjectTests.cpp
+++ b/test/JSObjectTests.cpp
@@ -500,4 +500,9 @@ TEST_F(JSObjectTests, JSFunctionCallback) {
   global_object.SetProperty("testJSFunctionCallback", js_function);
   
   XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
+
+  // testing NOOP function
+  JSFunction noop_function = js_context.CreateFunction();
+  XCTAssertTrue(noop_function(noop_function).IsUndefined());
+  
 }

--- a/test/JSObjectTests.cpp
+++ b/test/JSObjectTests.cpp
@@ -482,3 +482,22 @@ TEST_F(JSObjectTests, JSFunction) {
   XCTAssertFalse(js_function.IsArray());
   XCTAssertFalse(js_function.IsError());
 }
+
+TEST_F(JSObjectTests, JSFunctionCallback) {
+  JSContext js_context = js_context_group.CreateContext();
+  JSFunctionCallback callback = [js_context](const std::vector<JSValue> arguments, JSObject& this_object) {
+    return js_context.CreateString("Hello, "+static_cast<std::string>(arguments.at(0)));
+  };
+
+  JSFunction js_function = js_context.CreateFunction(callback);
+
+  XCTAssertTrue(js_function.IsFunction());
+  XCTAssertEqual("Hello, world", static_cast<std::string>(js_function("world", js_function)));
+  XCTAssertFalse(js_function.IsArray());
+  XCTAssertFalse(js_function.IsError());
+  
+  auto global_object = js_context.get_global_object();
+  global_object.SetProperty("testJSFunctionCallback", js_function);
+  
+  XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
+}

--- a/test/JSObjectTests.cpp
+++ b/test/JSObjectTests.cpp
@@ -339,6 +339,119 @@ TEST_F(JSObjectTests, JSObjectToJSArray) {
   XCTAssertEqual(nullptr, export_items.at(3));
 }
 
+TEST_F(JSObjectTests, StringVectorFromJSArray) {
+  JSContext js_context = js_context_group.CreateContext();
+
+  std::vector<JSValue> args = { 
+    js_context.CreateString("Hello 1"),
+    js_context.CreateString("Hello 2"),
+    js_context.CreateString("Hello 3")
+  };
+
+  JSObject js_object = js_context.CreateArray(args);
+  XCTAssertTrue(js_object.IsArray());
+  JSArray js_array = static_cast<JSArray>(js_object);
+  XCTAssertTrue(js_array.IsArray());
+  auto items = static_cast<std::vector<std::string>>(js_array);
+
+  XCTAssertEqual(3, js_array.GetLength());
+  XCTAssertEqual(3, items.size());
+
+  XCTAssertEqual("Hello 1", items.at(0));
+  XCTAssertEqual("Hello 2", items.at(1));
+  XCTAssertEqual("Hello 3", items.at(2));
+}
+
+TEST_F(JSObjectTests, BoolVectorFromJSArray) {
+  JSContext js_context = js_context_group.CreateContext();
+
+  std::vector<JSValue> args = { 
+    js_context.CreateBoolean(true),
+    js_context.CreateBoolean(false),
+    js_context.CreateBoolean(true)
+  };
+
+  JSObject js_object = js_context.CreateArray(args);
+  XCTAssertTrue(js_object.IsArray());
+  JSArray js_array = static_cast<JSArray>(js_object);
+  XCTAssertTrue(js_array.IsArray());
+  auto items = static_cast<std::vector<bool>>(js_array);
+
+  XCTAssertEqual(3, js_array.GetLength());
+  XCTAssertEqual(3, items.size());
+
+  XCTAssertTrue(items.at(0));
+  XCTAssertFalse(items.at(1));
+  XCTAssertTrue(items.at(2));
+}
+
+TEST_F(JSObjectTests, DoubleVectorFromJSArray) {
+  JSContext js_context = js_context_group.CreateContext();
+
+  std::vector<JSValue> args = { 
+    js_context.CreateNumber(1.1),
+    js_context.CreateNumber(1.12),
+    js_context.CreateNumber(1.123)
+  };
+
+  JSObject js_object = js_context.CreateArray(args);
+  XCTAssertTrue(js_object.IsArray());
+  JSArray js_array = static_cast<JSArray>(js_object);
+  XCTAssertTrue(js_array.IsArray());
+  auto items = static_cast<std::vector<double>>(js_array);
+
+  XCTAssertEqual(3, js_array.GetLength());
+  XCTAssertEqual(3, items.size());
+
+  XCTAssertEqual(1.1, items.at(0));
+  XCTAssertEqual(1.12, items.at(1));
+  XCTAssertEqual(1.123, items.at(2));
+}
+
+TEST_F(JSObjectTests, IntVectorFromJSArray) {
+  JSContext js_context = js_context_group.CreateContext();
+
+  std::vector<JSValue> args = { 
+    js_context.CreateNumber(123),
+    js_context.CreateNumber(123.4),
+    js_context.CreateNumber(-123)
+  };
+
+  JSObject js_object = js_context.CreateArray(args);
+  XCTAssertTrue(js_object.IsArray());
+  JSArray js_array = static_cast<JSArray>(js_object);
+  XCTAssertTrue(js_array.IsArray());
+  auto items = static_cast<std::vector<std::int32_t>>(js_array);
+
+  XCTAssertEqual(3, js_array.GetLength());
+  XCTAssertEqual(3, items.size());
+
+  XCTAssertEqual(123, items.at(0));
+  XCTAssertEqual(123, items.at(1));
+  XCTAssertEqual(-123, items.at(2));
+}
+
+TEST_F(JSObjectTests, UIntVectorFromJSArray) {
+  JSContext js_context = js_context_group.CreateContext();
+
+  std::vector<JSValue> args = { 
+    js_context.CreateNumber(123),
+    js_context.CreateNumber(123.4)
+  };
+
+  JSObject js_object = js_context.CreateArray(args);
+  XCTAssertTrue(js_object.IsArray());
+  JSArray js_array = static_cast<JSArray>(js_object);
+  XCTAssertTrue(js_array.IsArray());
+  auto items = static_cast<std::vector<std::uint32_t>>(js_array);
+
+  XCTAssertEqual(2, js_array.GetLength());
+  XCTAssertEqual(2, items.size());
+
+  XCTAssertEqual(123, items.at(0));
+  XCTAssertEqual(123, items.at(1));
+}
+
 TEST_F(JSObjectTests, JSDate) {
   JSContext js_context = js_context_group.CreateContext();
   JSDate js_date = js_context.CreateDate();

--- a/xcode/HALTests/JSObjectTests.mm
+++ b/xcode/HALTests/JSObjectTests.mm
@@ -353,6 +353,119 @@ namespace UnitTestConstants {
   XCTAssertEqual(nullptr, export_items.at(3));
 }
 
+- (void)testStringVectorFromJSArray {
+  JSContext js_context = js_context_group.CreateContext();
+
+  std::vector<JSValue> args = { 
+    js_context.CreateString("Hello 1"),
+    js_context.CreateString("Hello 2"),
+    js_context.CreateString("Hello 3")
+  };
+
+  JSObject js_object = js_context.CreateArray(args);
+  XCTAssertTrue(js_object.IsArray());
+  JSArray js_array = static_cast<JSArray>(js_object);
+  XCTAssertTrue(js_array.IsArray());
+  auto items = static_cast<std::vector<std::string>>(js_array);
+
+  XCTAssertEqual(3, js_array.GetLength());
+  XCTAssertEqual(3, items.size());
+
+  XCTAssertEqual("Hello 1", items.at(0));
+  XCTAssertEqual("Hello 2", items.at(1));
+  XCTAssertEqual("Hello 3", items.at(2));
+}
+
+- (void)testBoolVectorFromJSArray {
+  JSContext js_context = js_context_group.CreateContext();
+
+  std::vector<JSValue> args = { 
+    js_context.CreateBoolean(true),
+    js_context.CreateBoolean(false),
+    js_context.CreateBoolean(true)
+  };
+
+  JSObject js_object = js_context.CreateArray(args);
+  XCTAssertTrue(js_object.IsArray());
+  JSArray js_array = static_cast<JSArray>(js_object);
+  XCTAssertTrue(js_array.IsArray());
+  auto items = static_cast<std::vector<bool>>(js_array);
+
+  XCTAssertEqual(3, js_array.GetLength());
+  XCTAssertEqual(3, items.size());
+
+  XCTAssertTrue(items.at(0));
+  XCTAssertFalse(items.at(1));
+  XCTAssertTrue(items.at(2));
+}
+
+- (void)testDoubleVectorFromJSArray {
+  JSContext js_context = js_context_group.CreateContext();
+
+  std::vector<JSValue> args = { 
+    js_context.CreateNumber(1.1),
+    js_context.CreateNumber(1.12),
+    js_context.CreateNumber(1.123)
+  };
+
+  JSObject js_object = js_context.CreateArray(args);
+  XCTAssertTrue(js_object.IsArray());
+  JSArray js_array = static_cast<JSArray>(js_object);
+  XCTAssertTrue(js_array.IsArray());
+  auto items = static_cast<std::vector<double>>(js_array);
+
+  XCTAssertEqual(3, js_array.GetLength());
+  XCTAssertEqual(3, items.size());
+
+  XCTAssertEqual(1.1, items.at(0));
+  XCTAssertEqual(1.12, items.at(1));
+  XCTAssertEqual(1.123, items.at(2));
+}
+
+- (void)testIntVectorFromJSArray {
+  JSContext js_context = js_context_group.CreateContext();
+
+  std::vector<JSValue> args = { 
+    js_context.CreateNumber(123),
+    js_context.CreateNumber(123.4),
+    js_context.CreateNumber(-123)
+  };
+
+  JSObject js_object = js_context.CreateArray(args);
+  XCTAssertTrue(js_object.IsArray());
+  JSArray js_array = static_cast<JSArray>(js_object);
+  XCTAssertTrue(js_array.IsArray());
+  auto items = static_cast<std::vector<std::int32_t>>(js_array);
+
+  XCTAssertEqual(3, js_array.GetLength());
+  XCTAssertEqual(3, items.size());
+
+  XCTAssertEqual(123, items.at(0));
+  XCTAssertEqual(123, items.at(1));
+  XCTAssertEqual(-123, items.at(2));
+}
+
+- (void)testUIntVectorFromJSArray {
+  JSContext js_context = js_context_group.CreateContext();
+
+  std::vector<JSValue> args = { 
+    js_context.CreateNumber(123),
+    js_context.CreateNumber(123.4)
+  };
+
+  JSObject js_object = js_context.CreateArray(args);
+  XCTAssertTrue(js_object.IsArray());
+  JSArray js_array = static_cast<JSArray>(js_object);
+  XCTAssertTrue(js_array.IsArray());
+  auto items = static_cast<std::vector<std::uint32_t>>(js_array);
+
+  XCTAssertEqual(2, js_array.GetLength());
+  XCTAssertEqual(2, items.size());
+
+  XCTAssertEqual(123, items.at(0));
+  XCTAssertEqual(123, items.at(1));
+}
+
 - (void)testJSDate {
   JSContext js_context = js_context_group.CreateContext();
   JSDate js_date = js_context.CreateDate();

--- a/xcode/HALTests/JSObjectTests.mm
+++ b/xcode/HALTests/JSObjectTests.mm
@@ -509,11 +509,16 @@ namespace UnitTestConstants {
   XCTAssertEqual("Hello, world", static_cast<std::string>(js_function("world", js_function)));
   XCTAssertFalse(js_function.IsArray());
   XCTAssertFalse(js_function.IsError());
-	
+
   auto global_object = js_context.get_global_object();
   global_object.SetProperty("testJSFunctionCallback", js_function);
-	
+
   XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
+
+  // testing NOOP function
+  JSFunction noop_function = js_context.CreateFunction();
+  XCTAssertTrue(noop_function(noop_function).IsUndefined());
+
 }
 
 @end

--- a/xcode/HALTests/JSObjectTests.mm
+++ b/xcode/HALTests/JSObjectTests.mm
@@ -497,4 +497,23 @@ namespace UnitTestConstants {
   XCTAssertFalse(js_function.IsError());
 }
 
+- (void)testJSFunctionCallback {
+	JSContext js_context = js_context_group.CreateContext();
+	JSFunctionCallback callback = [js_context](const std::vector<JSValue> arguments, JSObject& this_object) {
+		return js_context.CreateString("Hello, "+static_cast<std::string>(arguments.at(0)));
+	};
+
+  JSFunction js_function = js_context.CreateFunction(callback);
+
+  XCTAssertTrue(js_function.IsFunction());
+  XCTAssertEqual("Hello, world", static_cast<std::string>(js_function("world", js_function)));
+	XCTAssertFalse(js_function.IsArray());
+	XCTAssertFalse(js_function.IsError());
+	
+	auto global_object = js_context.get_global_object();
+	global_object.SetProperty("testJSFunctionCallback", js_function);
+	
+	XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
+}
+
 @end

--- a/xcode/HALTests/JSObjectTests.mm
+++ b/xcode/HALTests/JSObjectTests.mm
@@ -498,22 +498,22 @@ namespace UnitTestConstants {
 }
 
 - (void)testJSFunctionCallback {
-	JSContext js_context = js_context_group.CreateContext();
-	JSFunctionCallback callback = [js_context](const std::vector<JSValue> arguments, JSObject& this_object) {
-		return js_context.CreateString("Hello, "+static_cast<std::string>(arguments.at(0)));
-	};
+  JSContext js_context = js_context_group.CreateContext();
+  JSFunctionCallback callback = [js_context](const std::vector<JSValue> arguments, JSObject& this_object) {
+    return js_context.CreateString("Hello, "+static_cast<std::string>(arguments.at(0)));
+  };
 
   JSFunction js_function = js_context.CreateFunction(callback);
 
   XCTAssertTrue(js_function.IsFunction());
   XCTAssertEqual("Hello, world", static_cast<std::string>(js_function("world", js_function)));
-	XCTAssertFalse(js_function.IsArray());
-	XCTAssertFalse(js_function.IsError());
+  XCTAssertFalse(js_function.IsArray());
+  XCTAssertFalse(js_function.IsError());
 	
-	auto global_object = js_context.get_global_object();
-	global_object.SetProperty("testJSFunctionCallback", js_function);
+  auto global_object = js_context.get_global_object();
+  global_object.SetProperty("testJSFunctionCallback", js_function);
 	
-	XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
+  XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
 }
 
 @end


### PR DESCRIPTION
Feedback from [titanium_mobile_windows](https://github.com/appcelerator/titanium_mobile_windows).

-  Add JSArray to `std::vector` of primitive types conversion 
- Add JSFunction::CreateFunction(JSFunctionCallback))

JSFunction::CreateFunction is a convenience method for creating a JavaScript function with a given callback as its implementation by C++ lambda/std::function etc. It is conceptually C++11 version of `JSObjectMakeFunctionWithCallback` JavaScriptCore C API.

```c++
  JSContext js_context = js_context_group.CreateContext();
  JSFunctionCallback callback = [js_context](const std::vector<JSValue> arguments, JSObject& this_object) {
    return js_context.CreateString("Hello, "+static_cast<std::string>(arguments.at(0)));
  };

  JSFunction js_function = js_context.CreateFunction(callback);

  XCTAssertEqual("Hello, world", static_cast<std::string>(js_function("world", js_function)));
```