### PR TITLE
Implement explicit conversion between pointer

### DIFF
--- a/include/HAL/JSContext.hpp
+++ b/include/HAL/JSContext.hpp
@@ -442,6 +442,16 @@ namespace HAL {
     JSContext(JSContext&&)          HAL_NOEXCEPT;
     JSContext& operator=(JSContext) HAL_NOEXCEPT;
     void swap(JSContext&)           HAL_NOEXCEPT;
+
+    // For interoperability with the JavaScriptCore C API.
+    explicit operator JSContextRef() const HAL_NOEXCEPT {
+      return js_global_context_ref__;
+    }
+    
+    explicit JSContext(JSContextRef js_context_ref) HAL_NOEXCEPT;
+    
+    // For interoperability with the JavaScriptCore C API.
+    explicit JSContext(JSGlobalContextRef js_global_context_ref__) HAL_NOEXCEPT;
     
   private:
     
@@ -451,39 +461,9 @@ namespace HAL {
     
     JSContext(const JSContextGroup& js_context_group, const JSClass& global_object_class) HAL_NOEXCEPT;
     
-    // These classes and functions need access to operator
-    // JSContextRef().
-    friend class JSValue;
-    friend class JSUndefined;
-    friend class JSNull;
-    friend class JSBoolean;
-    friend class JSNumber;
-    friend class JSObject;
-    friend class JSArray;
-    friend class JSDate;
-    friend class JSError;
-    friend class JSRegExp;
-    friend class JSFunction;
-    friend class JSPropertyNameArray;
-    
     HAL_EXPORT friend bool operator==(const JSValue& lhs, const JSValue& rhs) HAL_NOEXCEPT;
     HAL_EXPORT friend std::vector<JSValue> detail::to_vector(const JSContext&, size_t, const JSValueRef[]);
-    
-    // For interoperability with the JavaScriptCore C API.
-    explicit operator JSContextRef() const HAL_NOEXCEPT {
-      return js_global_context_ref__;
-    }
-    
-    // Only the JSExportClass static functions create a
-    // JSContext using the following constructor.
-    template<typename T>
-    friend class detail::JSExportClass;
-    
-    explicit JSContext(JSContextRef js_context_ref) HAL_NOEXCEPT;
-    
-    // For interoperability with the JavaScriptCore C API.
-    explicit JSContext(JSGlobalContextRef js_global_context_ref__) HAL_NOEXCEPT;
-    
+   
     // Prevent heap based objects.
     static void * operator new(std::size_t);       // #1: To prevent allocation of scalar objects
     static void * operator new [] (std::size_t);   // #2: To prevent allocation of array of objects

--- a/include/HAL/JSContextGroup.hpp
+++ b/include/HAL/JSContextGroup.hpp
@@ -82,19 +82,16 @@ namespace HAL {
     JSContextGroup(JSContextGroup&&)          HAL_NOEXCEPT;
     JSContextGroup& operator=(JSContextGroup) HAL_NOEXCEPT;
     void swap(JSContextGroup&)                HAL_NOEXCEPT;
-    
-  private:
-    
+
     // For interoperability with the JavaScriptCore C API.
     explicit JSContextGroup(JSContextGroupRef js_context_group_ref) HAL_NOEXCEPT;
-    
-    // JSContext needs access to operator JSContextGroupRef().
-    friend class JSContext;
     
     explicit operator JSContextGroupRef() const HAL_NOEXCEPT {
       return js_context_group_ref__;
     }
-    
+     
+  private:
+  
     // Prevent heap based objects.
     void* operator new(std::size_t)     = delete; // #1: To prevent allocation of scalar objects
     void* operator new [] (std::size_t) = delete; // #2: To prevent allocation of array of objects

--- a/include/HAL/JSObject.hpp
+++ b/include/HAL/JSObject.hpp
@@ -347,15 +347,6 @@ namespace HAL {
     static JSObject FindJSObjectFromPrivateData(JSContext js_context, void* private_data);
     static void     UnRegisterPrivateData(void* private_data);
     static void     RegisterPrivateData(JSObjectRef js_object_ref, void* private_data);
-    
-  protected:
-    
-    // In addition to derived classes, JSValue and JSExportClass need
-    // access to the following JSObject constructor.
-    
-    friend class JSValue;
-    friend class JSFunction;
-    
     // The JSExportClass static functions also need access to
     // GetPrivate and SetPrivate.
     template<typename T>
@@ -364,14 +355,13 @@ namespace HAL {
     // For interoperability with the JavaScriptCore C API.
     JSObject(const JSContext& js_context, JSObjectRef js_object_ref);
     
-    // These classes need access to operator JSObjectRef().
-    friend class JSPropertyNameArray;
-    
     // For interoperability with the JavaScriptCore C API.
     explicit operator JSObjectRef() const HAL_NOEXCEPT {
       return js_object_ref__;
     }
-    
+     
+  protected:
+  
     /*!
      @method
      

--- a/include/HAL/JSValue.hpp
+++ b/include/HAL/JSValue.hpp
@@ -316,34 +316,7 @@ namespace HAL {
     JSValue(JSValue&&)           HAL_NOEXCEPT;
     JSValue& operator=(JSValue);
     void swap(JSValue&)          HAL_NOEXCEPT;
-    
-  protected:
-    
-    // A JSContext can create a JSValue.
-    friend class JSContext;
-    
-    JSValue(const JSContext& js_context, const JSString& js_string, bool parse_as_json = false);
-    
-    
-    // These classes create a JSValue using the following constructor.
-    // friend class JSUndefined;
-    // friend class JSNull;
-    // friend class JSBoolean;
-    // friend class JSNumber;
-    friend class JSArray;    // for generating error messages
-    friend class JSDate;     // for generating error messages
-    friend class JSFunction; // for generating error messages
-    friend class JSRegExp;   // for generating error messages
-    friend class JSError;    // for generating error messages
-    
-    template<typename T>
-    friend class detail::JSExportClass;
-    
-    // JSObject needs access to the JSValue constructor for
-    // GetPrototype() and for generating error messages, as well as
-    // operator JSValueRef() for SetPrototype().
-    friend class JSObject;
-    
+
     // For interoperability with the JavaScriptCore C API.
     JSValue(const JSContext& js_context, JSValueRef js_value_ref) HAL_NOEXCEPT;
     
@@ -354,7 +327,14 @@ namespace HAL {
       }
       return js_value_ref__;
     }
+     
+  protected:
     
+    // A JSContext can create a JSValue.
+    friend class JSContext;
+    
+    JSValue(const JSContext& js_context, const JSString& js_string, bool parse_as_json = false);
+  
     // These classes and functions need access to operator
     // JSValueRef().
     HAL_EXPORT friend bool operator==(const JSValue& lhs, const JSValue& rhs) HAL_NOEXCEPT;

--- a/test/JSContextTests.cpp
+++ b/test/JSContextTests.cpp
@@ -36,6 +36,22 @@ TEST_F(JSContextTests, JSEvaluateScript) {
   XCTAssertEqual("Hello, world.", static_cast<std::string>(js_value));
 }
 
+TEST_F(JSContextTests, JSContext_intptr_t) {
+  JSContext js_context = js_context_group.CreateContext();
+  auto context_ref = static_cast<JSContextRef>(js_context);
+  auto context_ptr = reinterpret_cast<std::intptr_t>(context_ref);
+  auto js_context2 = JSContext(reinterpret_cast<JSContextRef>(context_ptr));
+  XCTAssertTrue(js_context == js_context2);
+}
+
+TEST_F(JSContextTests, JSContextGroup_intptr_t) {
+  JSContext js_context = js_context_group.CreateContext();
+  auto context_group_ref = static_cast<JSContextGroupRef>(js_context_group);
+  auto context_group_ptr = reinterpret_cast<std::intptr_t>(context_group_ref);
+  auto js_context_group2 = JSContextGroup(reinterpret_cast<JSContextGroupRef>(context_group_ptr));
+  XCTAssertTrue(js_context_group == js_context_group2);
+}
+
 TEST_F(JSContextTests, TIMOB_18855) {
   JSContext js_context = js_context_group.CreateContext();
   js_context.JSEvaluateScript("var start=new Date().getTime();");

--- a/test/JSObjectTests.cpp
+++ b/test/JSObjectTests.cpp
@@ -57,6 +57,16 @@ TEST_F(JSObjectTests, JSPropertyAttribute) {
   XCTAssertEqual(1, attributes.size());
 }
 
+TEST_F(JSObjectTests, JSObject_ptr_t) {
+  JSContext js_context = js_context_group.CreateContext();
+  JSObject js_object = js_context.CreateObject();
+
+  auto js_object_ref = static_cast<JSObjectRef>(js_object);
+  auto js_object_ptr = reinterpret_cast<std::intptr_t>(js_object_ref);
+  auto js_object2 = JSObject(js_context, reinterpret_cast<JSObjectRef>(js_object_ptr));
+  XCTAssertTrue(js_object == js_object2);
+} 
+
 TEST_F(JSObjectTests, API) {
   JSContext js_context = js_context_group.CreateContext();
   JSObject js_object = js_context.CreateObject();

--- a/test/JSValueTests.cpp
+++ b/test/JSValueTests.cpp
@@ -32,6 +32,16 @@ class JSValueTests : public testing::Test {
   JSContextGroup js_context_group;
 };
 
+TEST_F(JSValueTests, JSValue_ptr_t) {
+  JSContext js_context = js_context_group.CreateContext();
+  auto js_value = js_context.CreateNumber(123);
+
+  auto js_value_ref = static_cast<JSValueRef>(js_value);
+  auto js_value_ptr = reinterpret_cast<std::intptr_t>(js_value_ref);
+  auto js_value2 = JSValue(js_context, reinterpret_cast<JSValueRef>(js_value_ptr));
+  XCTAssertTrue(js_value == js_value2);
+}
+
 TEST_F(JSValueTests, JSUndefined) {
   JSContext js_context = js_context_group.CreateContext();
   JSUndefined js_undefined = js_context.CreateUndefined();


### PR DESCRIPTION
explicit conversion between pointer.

  - JSContextGroup
  - JSContext
  - JSObject
  - JSValue

This is needed especially for the values to be passed across WinRT boundary on Windows.

```c++
  JSContext js_context = js_context_group.CreateContext();
  auto context_ref = static_cast<JSContextRef>(js_context);
  auto context_ptr = reinterpret_cast<std::intptr_t>(context_ref);
  auto js_context2 = JSContext(reinterpret_cast<JSContextRef>(context_ptr));
  XCTAssertTrue(js_context == js_context2);
```