### PR TITLE
Use /LTCG flag when linking Release builds, as suggested by MS's link…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,12 @@ if (WIN32)
   # Therefore we disable /OPT:REF and /OPT:ICF for the Debug
   # configuration.
   set_property(TARGET HAL APPEND_STRING PROPERTY LINK_FLAGS_DEBUG "/OPT:NOREF /OPT:NOICF")
+
+  # When building against Release version of JSC, we see a warning from the linker:
+  # JavaScriptCore-Release.lib(JSStringRef.obj) : MSIL .netmodule or module compiled with /GL found; restarting link # with /LTCG; add /LTCG to the link command line to improve linker performance
+  #
+  # Hence we'll turn on LTCG for release builds of HAL...
+  set_property(TARGET HAL APPEND_STRING PROPERTY LINK_FLAGS_RELEASE "/LTCG")
 endif()
 
 if (NOT HAL_DISABLE_TESTS)


### PR DESCRIPTION
…er when we do Release builds of Titanium Mobile Windows