### PR TITLE
Add unit test for JSON.stringify

### DIFF
--- a/test/JSObjectTests.cpp
+++ b/test/JSObjectTests.cpp
@@ -516,3 +516,33 @@ TEST_F(JSObjectTests, JSFunctionCallback) {
   XCTAssertTrue(noop_function(noop_function).IsUndefined());
   
 }
+
+TEST_F(JSObjectTests, JSON_stringify) {
+  auto js_context = js_context_group.CreateContext();
+  auto global_object = js_context.get_global_object();
+  std::unordered_map<std::string, JSValue> properties = { 
+    { "double", js_context.CreateNumber(UnitTestConstants::pi) }
+  };
+
+  auto js_map = js_context.CreateObject(properties);
+
+  std::vector<JSValue> array_args = { 
+    js_context.CreateString("Hello"),
+    js_context.CreateNumber(123),
+    js_context.CreateNumber(UnitTestConstants::pi),
+    js_context.CreateBoolean(true),
+    js_context.CreateObject()
+  };
+
+  auto js_array = js_context.CreateArray(array_args);
+
+  global_object.SetProperty("js_map", js_map);
+  global_object.SetProperty("js_array", js_array);
+
+  auto js_result = js_context.JSEvaluateScript("JSON.stringify(js_map);");
+  XCTAssertEqual("{\"double\":3.141592653589793}", static_cast<std::string>(js_result));
+
+  js_result = js_context.JSEvaluateScript("JSON.stringify(js_array);");
+  XCTAssertEqual("[\"Hello\",123,3.141592653589793,true,{}]", static_cast<std::string>(js_result));
+}
+

--- a/test/JSValueTests.cpp
+++ b/test/JSValueTests.cpp
@@ -253,3 +253,50 @@ TEST_F(JSValueTests, CopyingValuesBetweenContexts) {
   // You can't copy JSValue's between different JSContextGroups.
   ASSERT_THROW(js_value_3 = js_value_1, std::runtime_error);
 }
+
+TEST_F(JSValueTests, JSON_Stringify) {
+  auto js_context   = js_context_group.CreateContext();
+  auto js_undefined = js_context.CreateUndefined();
+  auto js_null  = js_context.CreateNull();
+  auto js_false = js_context.CreateBoolean(false);
+  auto js_true  = js_context.CreateBoolean(true);
+  auto js_double = js_context.CreateNumber(UnitTestConstants::pi);
+  auto js_int32  = js_context.CreateNumber(int32_t(42));
+  auto js_uint32 = js_context.CreateNumber(uint32_t(42));
+  auto js_string = js_context.CreateString("Hello, World");
+
+  auto global_object = js_context.get_global_object();
+
+  global_object.SetProperty("js_undefined", js_undefined);
+  global_object.SetProperty("js_null", js_null);
+  global_object.SetProperty("js_false", js_false);
+  global_object.SetProperty("js_true", js_true);
+  global_object.SetProperty("js_double", js_double);
+  global_object.SetProperty("js_int32", js_int32);
+  global_object.SetProperty("js_uint32", js_uint32);
+  global_object.SetProperty("js_string", js_string);
+
+  auto js_result = js_context.JSEvaluateScript("JSON.stringify(js_undefined);");
+  XCTAssertEqual("undefined", static_cast<std::string>(js_result));
+
+  js_result = js_context.JSEvaluateScript("JSON.stringify(js_null);");
+  XCTAssertEqual("null", static_cast<std::string>(js_result));
+
+  js_result = js_context.JSEvaluateScript("JSON.stringify(js_false);");
+  XCTAssertEqual("false", static_cast<std::string>(js_result));
+
+  js_result = js_context.JSEvaluateScript("JSON.stringify(js_true);");
+  XCTAssertEqual("true", static_cast<std::string>(js_result));
+
+  js_result = js_context.JSEvaluateScript("JSON.stringify(js_double);");
+  XCTAssertEqual("3.141592653589793", static_cast<std::string>(js_result));
+
+  js_result = js_context.JSEvaluateScript("JSON.stringify(js_int32);");
+  XCTAssertEqual("42", static_cast<std::string>(js_result));
+
+  js_result = js_context.JSEvaluateScript("JSON.stringify(js_uint32);");
+  XCTAssertEqual("42", static_cast<std::string>(js_result));
+
+  js_result = js_context.JSEvaluateScript("JSON.stringify(js_string);");
+  XCTAssertEqual("\"Hello, World\"", static_cast<std::string>(js_result));
+}


### PR DESCRIPTION
Making sure HAL types and JSExport objects support `JSON.stringify`.