### PR TITLE
Fix HAL unit tests on latest JavaScriptCore

### DIFF
--- a/include/HAL/JSContextGroup.hpp
+++ b/include/HAL/JSContextGroup.hpp
@@ -102,6 +102,7 @@ namespace HAL {
     // need to be exported from a DLL.
 #pragma warning(push)
 #pragma warning(disable: 4251)
+    bool managed__ { false };
     JSContextGroupRef js_context_group_ref__;
 #pragma warning(pop)
     

--- a/src/JSContextGroup.cpp
+++ b/src/JSContextGroup.cpp
@@ -34,12 +34,15 @@ namespace HAL {
     assert(js_context_group_ref__);
     HAL_LOG_TRACE("JSContextGroup:: retain ", js_context_group_ref__, " for ", this);
     JSContextGroupRetain(js_context_group_ref__);
+    managed__ = true;
   }
   
   JSContextGroup::~JSContextGroup() HAL_NOEXCEPT {
     HAL_LOG_TRACE("JSContextGroup:: dtor ", this);
     HAL_LOG_TRACE("JSContextGroup:: release ", js_context_group_ref__, " for ", this);
-    JSContextGroupRelease(js_context_group_ref__);
+    if (managed__) {
+      JSContextGroupRelease(js_context_group_ref__);
+    }
   }
   
   JSContextGroup::JSContextGroup(const JSContextGroup& rhs) HAL_NOEXCEPT
@@ -47,6 +50,7 @@ namespace HAL {
     HAL_LOG_TRACE("JSContextGroup:: copy ctor ", this);
     HAL_LOG_TRACE("JSContextGroup:: retain ", js_context_group_ref__, " for ", this);
     JSContextGroupRetain(js_context_group_ref__);
+    managed__ = true;
   }
   
   JSContextGroup::JSContextGroup(JSContextGroup&& rhs) HAL_NOEXCEPT
@@ -54,6 +58,7 @@ namespace HAL {
     HAL_LOG_TRACE("JSContextGroup:: move ctor ", this);
     HAL_LOG_TRACE("JSContextGroup:: retain ", js_context_group_ref__, " for ", this);
     JSContextGroupRetain(js_context_group_ref__);
+    managed__ = true;
   }
   
   JSContextGroup& JSContextGroup::operator=(JSContextGroup rhs) HAL_NOEXCEPT {

--- a/src/JSFunction.cpp
+++ b/src/JSFunction.cpp
@@ -26,7 +26,13 @@ JSFunction::JSFunction(const JSContext& js_context, const JSString& function_nam
         : JSObject(js_context, MakeFunction(js_context, function_name, callback)) {
 }
 
-JSObjectRef JSFunction::MakeFunction(const JSContext& js_context, const JSString& body, const std::vector<JSString>& parameter_names, const JSString& function_name, const JSString& source_url, int starting_line_number) {
+JSObjectRef JSFunction::MakeFunction(const JSContext& js_context, const JSString& body, const std::vector<JSString>& parameter_names, const JSString& func_name, const JSString& source_url, int starting_line_number) {
+
+    JSString function_name = func_name;
+    if (function_name == "") {
+        function_name = JSString("anonymous");
+    }
+
     JSValueRef exception { nullptr };
     JSStringRef source_url_ref = (source_url.length() > 0) ? static_cast<JSStringRef>(source_url) : nullptr;
     JSObjectRef js_object_ref = nullptr;

--- a/test/JSObjectTests.cpp
+++ b/test/JSObjectTests.cpp
@@ -33,7 +33,7 @@ class JSObjectTests : public testing::Test {
 };
 
 TEST_F(JSObjectTests, ObjectSizes) {
-  XCTAssertEqual(sizeof(std::intptr_t)                         , sizeof(JSContextGroup));
+  XCTAssertEqual(sizeof(std::intptr_t)  + sizeof(std::intptr_t), sizeof(JSContextGroup));
   XCTAssertEqual(sizeof(JSContextGroup) + sizeof(std::intptr_t), sizeof(JSContext));
   
   // JSValue and JSObject are base classes, so have an extra pointer for the


### PR DESCRIPTION
- Give name to anonymous function
- Don't `JSContextGroupRelease` when it's not `JSContextGroupRetain`-ed
