### PR TITLE
Remove extra definition of JSContextGetGlobalContext

### DIFF
--- a/include/HAL/detail/JSBase.hpp
+++ b/include/HAL/detail/JSBase.hpp
@@ -60,12 +60,4 @@
 #include "HAL/detail/JSPerformanceCounter.hpp"
 #include <JavaScriptCore/JavaScript.h>
 
-/*!
-  @function
-  @abstract Gets the global context of a JavaScript execution context.
-  @param ctx The JSContext whose global context you want to get.
-  @result ctx's global context.
-*/
-extern "C" JSGlobalContextRef JSContextGetGlobalContext(JSContextRef ctx);
-
 #endif  // _HAL_DETAIL_JSBASE_HPP_


### PR DESCRIPTION
When doing builds locally I'm seeing lots of warnings about inconsistent DLL linkage due to re-define of JSContextGetGlobalContext