### PR TITLE
JSString u16string API cleanup

### DIFF
--- a/include/HAL/JSString.hpp
+++ b/include/HAL/JSString.hpp
@@ -128,17 +128,6 @@ namespace HAL {
        */
       operator std::string() const HAL_NOEXCEPT;
       
-      /*!
-       @method
-       
-       @abstract Convert this JavaScript string to a UTF-16 encoded
-       std::u16string.
-       
-       @result This JavaScript string converted to a UTF-16 encoded
-       std::u16string.
-       */
-      operator std::u16string() const HAL_NOEXCEPT;
-      
       std::size_t hash_value() const;
       
       ~JSString()                   HAL_NOEXCEPT;
@@ -147,6 +136,14 @@ namespace HAL {
       JSString& operator=(JSString) HAL_NOEXCEPT;
       void swap(JSString&)          HAL_NOEXCEPT;
 
+      // For interoperability with the JavaScriptCore C API.
+      explicit JSString(JSStringRef js_string_ref) HAL_NOEXCEPT;
+      
+      // For interoperability with the JavaScriptCore C API.
+      explicit operator JSStringRef() const {
+        return js_string_ref__;
+      }
+      
     private:
       
       // These classes and functions need access to operator
@@ -159,19 +156,11 @@ namespace HAL {
       
       friend std::vector<JSStringRef> detail::to_vector(const std::vector<JSString>&);
       
-      // For interoperability with the JavaScriptCore C API.
-      explicit operator JSStringRef() const {
-        return js_string_ref__;
-      }
-      
       // Only the following classes and functions can create a JSString.
       friend class JSValue;
       
       template<typename T>
       friend class detail::JSExportClass; // static functions
-      
-      // For interoperability with the JavaScriptCore C API.
-      explicit JSString(JSStringRef js_string_ref) HAL_NOEXCEPT;
       
       // Prevent heap based objects.
       static void * operator new(std::size_t);     // #1: To prevent allocation of scalar objects
@@ -186,7 +175,6 @@ namespace HAL {
 #pragma warning(disable: 4251)
       JSStringRef    js_string_ref__ { nullptr };
       std::string    string__;
-      std::u16string u16string__;
       std::size_t    hash_value__;
 #pragma warning(pop)
       

--- a/src/JSString.cpp
+++ b/src/JSString.cpp
@@ -23,7 +23,6 @@ namespace HAL {
     HAL_LOG_TRACE("JSString:: ctor 1 ", this);
     HAL_LOG_TRACE("JSString:: retain ", js_string_ref__, " (implicit) for ", this);
     const JSChar* string_ptr = JSStringGetCharactersPtr(js_string_ref__);
-    u16string__ = std::u16string(string_ptr, string_ptr + length());
     
     std::hash<std::string> hash_function = std::hash<std::string>();
     hash_value__ = hash_function(static_cast<std::string>(string__));
@@ -36,7 +35,6 @@ namespace HAL {
     HAL_LOG_TRACE("JSString:: ctor 2 ", this);
     HAL_LOG_TRACE("JSString:: retain ", js_string_ref__, " (implicit) for ", this);
     const JSChar* string_ptr = JSStringGetCharactersPtr(js_string_ref__);
-    u16string__ = std::u16string(string_ptr, string_ptr + length());
 
     std::hash<std::string> hash_function = std::hash<std::string>();
     hash_value__ = hash_function(static_cast<std::string>(string__));
@@ -60,10 +58,6 @@ namespace HAL {
     return string__;
   }
   
-  JSString::operator std::u16string() const HAL_NOEXCEPT {
-    return u16string__;
-  }
-  
   std::size_t JSString::hash_value() const {
     return hash_value__;
   }
@@ -77,7 +71,6 @@ namespace HAL {
   JSString::JSString(const JSString& rhs) HAL_NOEXCEPT
   : js_string_ref__(rhs.js_string_ref__)
   , string__(rhs.string__)
-  , u16string__(rhs.u16string__)
   , hash_value__(rhs.hash_value__) {
     HAL_LOG_TRACE("JSString:: copy ctor ", this);
     HAL_LOG_TRACE("JSString:: retain ", js_string_ref__, " for ", this);
@@ -87,7 +80,6 @@ namespace HAL {
   JSString::JSString(JSString&& rhs) HAL_NOEXCEPT
   : js_string_ref__(rhs.js_string_ref__)
   , string__(std::move(rhs.string__))
-  , u16string__(std::move(rhs.u16string__))
   , hash_value__(std::move(rhs.hash_value__)) {
     HAL_LOG_TRACE("JSString:: move ctor ", this);
     HAL_LOG_TRACE("JSString:: retain ", js_string_ref__, " for ", this);
@@ -109,7 +101,6 @@ namespace HAL {
     // By swapping the members of two classes, the two classes are
     // effectively swapped.
     swap(js_string_ref__, other.js_string_ref__);
-    swap(u16string__    , other.u16string__);
     swap(string__       , other.string__);
     swap(hash_value__   , other.hash_value__);
   }
@@ -117,20 +108,16 @@ namespace HAL {
   // For interoperability with the JavaScriptCore C API.
   JSString::JSString(JSStringRef js_string_ref) HAL_NOEXCEPT
   : js_string_ref__(js_string_ref) {
-    static std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> converter;
     assert(js_string_ref__);
     JSStringRetain(js_string_ref__);
     HAL_LOG_TRACE("JSString:: ctor 3 ", this);
     HAL_LOG_TRACE("JSString:: retain ", js_string_ref__, " for ", this);
 
     const JSChar* string_ptr = JSStringGetCharactersPtr(js_string_ref__);
-    u16string__ = std::u16string(string_ptr, string_ptr + length());
-    string__    = std::string(converter.to_bytes(u16string__));
+    string__ = std::string(string_ptr, string_ptr + length());
     
     std::hash<std::string> hash_function = std::hash<std::string>();
     hash_value__ = hash_function(static_cast<std::string>(string__));
-
-    //HAL_LOG_TRACE("JSString::JSString(JSStringRef)");
   }
   
   bool operator==(const JSString& lhs, const JSString& rhs) {

--- a/test/JSStringTests.cpp
+++ b/test/JSStringTests.cpp
@@ -77,3 +77,14 @@ TEST(JSStringTests, StdString) {
   // No implicit conversions.
   //XCTAssertEqual(std::string("hello, std::string"), JSString(string2));
 }
+
+TEST(JSStringTests, from_JSStringRef) {
+  JSString string1 { "hello, JSString" };
+  JSStringRef string1_ref = static_cast<JSStringRef>(string1);
+
+  JSString string2 = JSString(string1_ref);
+  XCTAssertEqual(string1, string2);
+  XCTAssertEqual(string1.length(), string2.length());
+  XCTAssertEqual(static_cast<std::string>(string1), static_cast<std::string>(string2));
+  XCTAssertEqual("hello, JSString", static_cast<std::string>(string2));
+}


### PR DESCRIPTION
Cleanup JSString API regarding u16string. Currently JSString keeps reference to `std::u16string` as well as `std::string` but I don't think we want to keep `u16string` as member of JSString.  I also think conversion operator between `u16string` is not necessary when thinking about current usage. We can just deal with utf-8 through std::string.

- Remove u16string related function/variable from JSString
- Make JSString to JSStringRef API public, just like JSValue/JSObject does.