### PR TITLE
Fix: JSString should use UTF-8 string

### DIFF
--- a/src/JSString.cpp
+++ b/src/JSString.cpp
@@ -22,7 +22,6 @@ namespace HAL {
   , string__(string) {
     HAL_LOG_TRACE("JSString:: ctor 1 ", this);
     HAL_LOG_TRACE("JSString:: retain ", js_string_ref__, " (implicit) for ", this);
-    const JSChar* string_ptr = JSStringGetCharactersPtr(js_string_ref__);
     
     std::hash<std::string> hash_function = std::hash<std::string>();
     hash_value__ = hash_function(static_cast<std::string>(string__));
@@ -34,7 +33,6 @@ namespace HAL {
   , string__(string) {
     HAL_LOG_TRACE("JSString:: ctor 2 ", this);
     HAL_LOG_TRACE("JSString:: retain ", js_string_ref__, " (implicit) for ", this);
-    const JSChar* string_ptr = JSStringGetCharactersPtr(js_string_ref__);
 
     std::hash<std::string> hash_function = std::hash<std::string>();
     hash_value__ = hash_function(static_cast<std::string>(string__));
@@ -113,8 +111,11 @@ namespace HAL {
     HAL_LOG_TRACE("JSString:: ctor 3 ", this);
     HAL_LOG_TRACE("JSString:: retain ", js_string_ref__, " for ", this);
 
-    const JSChar* string_ptr = JSStringGetCharactersPtr(js_string_ref__);
-    string__ = std::string(string_ptr, string_ptr + length());
+    const auto size = JSStringGetMaximumUTF8CStringSize(js_string_ref__);
+    auto buffer = new char[size];
+    JSStringGetUTF8CString(js_string_ref__, buffer, size);
+    string__ = std::string(buffer);
+    delete[] buffer;
     
     std::hash<std::string> hash_function = std::hash<std::string>();
     hash_value__ = hash_function(static_cast<std::string>(string__));

--- a/test/JSStringTests.cpp
+++ b/test/JSStringTests.cpp
@@ -88,3 +88,16 @@ TEST(JSStringTests, from_JSStringRef) {
   XCTAssertEqual(static_cast<std::string>(string1), static_cast<std::string>(string2));
   XCTAssertEqual("hello, JSString", static_cast<std::string>(string2));
 }
+
+TEST(JSStringTests, UTF8) {
+  JSString string1 { "spät" };
+  JSStringRef string1_ref = static_cast<JSStringRef>(string1);
+
+  JSString string2 = JSString(string1_ref);
+  XCTAssertEqual(string1, string2);
+  XCTAssertEqual(4, string2.length());
+  XCTAssertEqual(string1.length(), string2.length());
+  XCTAssertEqual(static_cast<std::string>(string1), static_cast<std::string>(string2));
+  XCTAssertEqual("spät", static_cast<std::string>(string2));
+}
+


### PR DESCRIPTION
JSString should use JSStringGetUTF8CString instead of JSStringGetCharactersPtr.