### PR TITLE
Enable SAFESEH for Windows Store/Phone build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,10 +209,16 @@ if (WIN32)
   # Therefore we test for the processor architecture we are targeting
   # and if its i386 (i.e. the emulator) then we pass /SAFESEH:NO to
   # the linker.
-  include(${PROJECT_SOURCE_DIR}/cmake/TargetArch.cmake)
-  target_architecture(target_architecture)
-  if (${target_architecture} STREQUAL i386)
-    set_property(TARGET HAL APPEND_STRING PROPERTY LINK_FLAGS " /SAFESEH:NO")
+  # 
+  # If target platform is Windows Phone/Store,
+  # we should not disable SAFESEH otherwise Windows App Certification will fail.
+  # 
+  if (NOT CMAKE_SYSTEM_NAME MATCHES "^Windows(Phone|Store)$")
+    include(${PROJECT_SOURCE_DIR}/cmake/TargetArch.cmake)
+    target_architecture(target_architecture)
+    if (${target_architecture} STREQUAL i386)
+      set_property(TARGET HAL APPEND_STRING PROPERTY LINK_FLAGS " /SAFESEH:NO")
+    endif()
   endif()
 
   # Silence this warning when lnking the Debug configuration:


### PR DESCRIPTION
Part of [TIMOB-20201](https://jira.appcelerator.org/browse/TIMOB-20201)

We have been disabling SAFESEH linker option just to supress compiler warning message for simulator according to CMakeLists.txt#L195. This PR enables `SAFESEH` for Windows Phone/Store app so it passes Windows App Certification.