### PR TITLE
Implement property cache

### DIFF
--- a/examples/ChildWidget.cpp
+++ b/examples/ChildWidget.cpp
@@ -34,6 +34,7 @@ void ChildWidget::JSExportInitialize() {
   JSExport<ChildWidget>::SetParent(JSExport<Widget>::Class());
   JSExport<ChildWidget>::AddValueProperty("name", std::mem_fn(&ChildWidget::js_get_name));
   JSExport<ChildWidget>::AddValueProperty("my_name", std::mem_fn(&ChildWidget::js_get_my_name));
+  JSExport<ChildWidget>::AddConstantProperty("pi"  , std::mem_fn(&ChildWidget::js_get_pi));
 }
 
 JSValue ChildWidget::js_get_name() const HAL_NOEXCEPT {
@@ -43,4 +44,9 @@ JSValue ChildWidget::js_get_name() const HAL_NOEXCEPT {
 
 JSValue ChildWidget::js_get_my_name() const HAL_NOEXCEPT {
   return get_context().CreateString("child widget");
+}
+
+JSValue ChildWidget::js_get_pi() HAL_NOEXCEPT {
+  count_for_child_pi__++;
+  return get_context().CreateString("hello pi");
 }

--- a/examples/ChildWidget.hpp
+++ b/examples/ChildWidget.hpp
@@ -35,9 +35,13 @@ public:
   
   JSValue js_get_name() const HAL_NOEXCEPT;
   JSValue js_get_my_name() const HAL_NOEXCEPT;
+  JSValue js_get_pi() HAL_NOEXCEPT;
   
+  std::uint32_t get_count_for_child_pi() {
+    return count_for_child_pi__;
+  }
 private:
-
+  std::uint32_t count_for_child_pi__ { 0 };
 };
 
 inline

--- a/examples/Widget.cpp
+++ b/examples/Widget.cpp
@@ -210,7 +210,7 @@ void Widget::JSExportInitialize() {
   JSExport<Widget>::AddValueProperty("name"       , std::mem_fn(&Widget::js_get_name)  , std::mem_fn(&Widget::js_set_name));
   JSExport<Widget>::AddValueProperty("number"     , std::mem_fn(&Widget::js_get_number), std::mem_fn(&Widget::js_set_number));
   JSExport<Widget>::AddValueProperty("value"     , std::mem_fn(&Widget::js_get_value), std::mem_fn(&Widget::js_set_value));
-  JSExport<Widget>::AddValueProperty("pi"         , std::mem_fn(&Widget::js_get_pi));
+  JSExport<Widget>::AddConstantProperty("pi"     , std::mem_fn(&Widget::js_get_pi));
   JSExport<Widget>::AddFunctionProperty("helloCallback", std::mem_fn(&Widget::js_helloLambda));
   JSExport<Widget>::AddFunctionProperty("sayHello", std::mem_fn(&Widget::js_sayHello));
   JSExport<Widget>::AddFunctionProperty("sayHelloWithCallback", std::mem_fn(&Widget::js_sayHelloWithCallback));
@@ -264,7 +264,8 @@ bool Widget::js_set_value(const JSValue& value) HAL_NOEXCEPT {
   return true;
 }
 
-JSValue Widget::js_get_pi() const {
+JSValue Widget::js_get_pi() HAL_NOEXCEPT {
+  count_for_pi__++;
   return get_context().CreateNumber(get_pi());
 }
 

--- a/examples/Widget.hpp
+++ b/examples/Widget.hpp
@@ -11,6 +11,7 @@
 
 #include "HAL/HAL.hpp"
 #include <string>
+#include <unordered_map>
 
 using namespace HAL;
 
@@ -53,6 +54,10 @@ public:
   std::string testMemberObjectProperty() const HAL_NOEXCEPT;
   std::string testMemberArrayProperty()  const HAL_NOEXCEPT;
   std::string testCallAsFunction(JSObject& this_object)       HAL_NOEXCEPT;
+
+  std::uint32_t get_count_for_pi() {
+    return count_for_pi__;
+  }
   
   virtual ~Widget()                HAL_NOEXCEPT;
   Widget(const Widget&)            HAL_NOEXCEPT;
@@ -81,7 +86,8 @@ public:
   JSValue js_get_number() const                HAL_NOEXCEPT;
   bool    js_set_number(const JSValue& number) HAL_NOEXCEPT;
   
-  JSValue js_get_pi() const;
+  // Remove "const" to test lazy loading
+  JSValue js_get_pi() HAL_NOEXCEPT;
   
   JSValue js_get_value() const                HAL_NOEXCEPT;
   bool    js_set_value(const JSValue& value) HAL_NOEXCEPT;
@@ -127,6 +133,7 @@ private:
   JSRegExp   jsregexp__;
   JSObject   hello_callback__;
 
+  std::uint32_t count_for_pi__ { 0 };
 };
 
 inline

--- a/include/HAL/JSExport.hpp
+++ b/include/HAL/JSExport.hpp
@@ -213,7 +213,43 @@ namespace HAL {
                                  detail::GetNamedValuePropertyCallback<T> get_callback,
                                  detail::SetNamedValuePropertyCallback<T> set_callback = nullptr,
                                  bool enumerable = true);
-    
+
+    /*!
+     @method
+     
+     @abstract Add a function property to your JavaScript object with
+     the 'DontDelete' and 'ReadOnly' attributes. By default the
+     property is enumerable unless you specify otherwise.
+     
+     @discussion For example, given this class definition:
+     
+     class Foo {
+     JSValue Hello(const std::vector<JSValue>& arguments);
+     };
+     
+     You would call the builer like this:
+     
+     JSExportClassDefinitionBuilder<Foo> builder("Foo");
+     builder.AddFunctionProperty("hello", &Foo::Hello);
+     
+     @param function_name A JSString containing the function's name.
+     
+     @param enumerable An optional property attribute that specifies
+     whether the property is enumerable. The default value is true,
+     which means the property is enumerable.
+     
+     @throws std::invalid_argument exception under these preconditions:
+     
+     1. If function_name is empty.
+     
+     2. If function_callback is not provided.
+     
+     @result A reference to the builder for chaining.
+     */
+    static void AddConstantProperty(const JSString& property_name,
+                                 detail::GetNamedValuePropertyCallback<T> get_callback,
+                                 bool enumerable = true);
+     
     /*!
      @method
      
@@ -523,6 +559,11 @@ namespace HAL {
   template<typename T>
   void JSExport<T>::AddValueProperty(const JSString& property_name, detail::GetNamedValuePropertyCallback<T> get_callback, detail::SetNamedValuePropertyCallback<T> set_callback, bool enumerable) {
     builder__.AddValueProperty(property_name, get_callback, set_callback);
+  }
+
+  template<typename T>
+  void JSExport<T>::AddConstantProperty(const JSString& property_name, detail::GetNamedValuePropertyCallback<T> get_callback, bool enumerable) {
+    builder__.AddConstantProperty(property_name, get_callback, enumerable);
   }
   
   template<typename T>

--- a/include/HAL/detail/JSExportCallbacks.hpp
+++ b/include/HAL/detail/JSExportCallbacks.hpp
@@ -44,7 +44,7 @@ namespace HAL { namespace detail {
    @result Return the named property's value.
    */
   template<typename T>
-  using GetNamedValuePropertyCallback = std::function<JSValue(const T&)>;
+  using GetNamedValuePropertyCallback = std::function<JSValue(T&)>;
   
   /*!
    @typedef SetNamedValuePropertyCallback
@@ -188,7 +188,7 @@ namespace HAL { namespace detail {
    prototype chain.
    */
   template<typename T>
-  using GetPropertyCallback = std::function<JSValue(const T&, const JSString&)>;
+  using GetPropertyCallback = std::function<JSValue(T&, const JSString&)>;
   
   /*!
    @typedef SetPropertyCallback
@@ -306,7 +306,7 @@ namespace HAL { namespace detail {
    @result void
    */
   template<typename T>
-  using GetPropertyNamesCallback = std::function<void(const T&, JSPropertyNameAccumulator&)>;
+  using GetPropertyNamesCallback = std::function<void(T&, JSPropertyNameAccumulator&)>;
   
   /*!
    @typedef CallAsFunctionCallback

--- a/include/HAL/detail/JSExportClassDefinition.hpp
+++ b/include/HAL/detail/JSExportClassDefinition.hpp
@@ -67,6 +67,7 @@ namespace HAL { namespace detail {
     template<typename U>
     friend class JSExportClass;
     
+    std::unordered_set<std::string>               named_constants__;
     JSExportNamedValuePropertyCallbackMap_t<T>    named_value_property_callback_map__;
     JSExportNamedFunctionPropertyCallbackMap_t<T> named_function_property_callback_map__;
     HasPropertyCallback<T>                        has_property_callback__        { nullptr };
@@ -81,6 +82,7 @@ namespace HAL { namespace detail {
   template<typename T>
   JSExportClassDefinition<T>::JSExportClassDefinition(const JSExportClassDefinition<T>& rhs) HAL_NOEXCEPT
   : JSClassDefinition(rhs)
+  , named_constants__(rhs.named_constants__)
   , named_value_property_callback_map__(rhs.named_value_property_callback_map__)
   , named_function_property_callback_map__(rhs.named_function_property_callback_map__)
   , has_property_callback__(rhs.has_property_callback__)
@@ -99,6 +101,7 @@ namespace HAL { namespace detail {
   template<typename T>
   JSExportClassDefinition<T>::JSExportClassDefinition(JSExportClassDefinition<T>&& rhs) HAL_NOEXCEPT
   : JSClassDefinition(rhs)
+  , named_constants__(std::move(rhs.named_constants__))
   , named_value_property_callback_map__(std::move(rhs.named_value_property_callback_map__))
   , named_function_property_callback_map__(std::move(rhs.named_function_property_callback_map__))
   , has_property_callback__(std::move(rhs.has_property_callback__))
@@ -118,6 +121,7 @@ namespace HAL { namespace detail {
   JSExportClassDefinition<T>& JSExportClassDefinition<T>::operator=(const JSExportClassDefinition<T>& rhs) HAL_NOEXCEPT {
     HAL_JSCLASSDEFINITION_LOCK_GUARD;
     JSClassDefinition::operator=(rhs);
+    named_constants__                      = rhs.named_constants__;
     named_value_property_callback_map__    = rhs.named_value_property_callback_map__;
     named_function_property_callback_map__ = rhs.named_function_property_callback_map__;
     has_property_callback__                = rhs.has_property_callback__;
@@ -155,6 +159,7 @@ namespace HAL { namespace detail {
       
       // By swapping the members of two classes, the two classes are
       // effectively swapped.
+      swap(named_constants__                     , other.named_constants__);
       swap(named_value_property_callback_map__   , other.named_value_property_callback_map__);
       swap(named_function_property_callback_map__, other.named_function_property_callback_map__);
       swap(has_property_callback__               , other.has_property_callback__);

--- a/test/JSExportTests.cpp
+++ b/test/JSExportTests.cpp
@@ -65,7 +65,7 @@ TEST_F(JSExportTests, JSExportClassDefinitionBuilder) {
   builder
       .AddValueProperty("name", std::mem_fn(&Widget::js_get_name), std::mem_fn(&Widget::js_set_name))
       .AddValueProperty("number", std::mem_fn(&Widget::js_get_number), std::mem_fn(&Widget::js_set_number))
-      .AddValueProperty("pi", std::mem_fn(&Widget::js_get_pi))
+      .AddConstantProperty("pi", std::mem_fn(&Widget::js_get_pi))
       .AddFunctionProperty("sayhello", std::mem_fn(&Widget::js_sayHello))
   // .Function(&Widget::CallAsFunction)
   // .ConvertType(&Widget::ConvertToType);
@@ -94,6 +94,10 @@ TEST_F(JSExportTests, JSExport) {
   result = js_context.JSEvaluateScript("Widget.name;");
   XCTAssertTrue(result.IsString());
   XCTAssertEqual("world", static_cast<std::string>(result));
+
+  result = js_context.JSEvaluateScript("Widget.pi;");
+  XCTAssertTrue(result.IsNumber());
+  XCTAssertEqual(3.141592653589793, static_cast<double>(result));
 
   result = js_context.JSEvaluateScript("Widget.sayHello();");
   XCTAssertTrue(result.IsString());
@@ -143,6 +147,13 @@ TEST_F(JSExportTests, JSExport) {
   result = js_context.JSEvaluateScript("var widget = new Widget('baz', 999); widget.sayHello();");
   XCTAssertTrue(result.IsString());
   XCTAssertEqual("Hello, baz. Your number is 999.", static_cast<std::string>(result));
+
+  // test constant cache
+  XCTAssertEqual(1, widget_ptr->get_count_for_pi());
+  result = js_context.JSEvaluateScript("Widget.pi;");
+  XCTAssertTrue(result.IsNumber());
+  XCTAssertEqual(3.141592653589793, static_cast<double>(result));
+  XCTAssertEqual(1, widget_ptr->get_count_for_pi());
 
   // FIXME
   auto string_ptr = widget.GetPrivate<std::string>();


### PR DESCRIPTION
Part of [TIMOB-20256](https://jira.appcelerator.org/browse/TIMOB-20256).

## Background

From the starting point of HAL, we have been declaring proxy property using C++ object member by holding `JSValue`.

```c++
class Widget : public JSExportObject, public JSExport<Widget> {
  private:
      JSValue myProperty_1__;
      JSValue myProperty_2__;
};
```

In this case we are creating these instances at proxy constructor:

```c++
Widget::Widget(const JSContext& js_context) HAL_NOEXCEPT
  : JSExportObject(js_context)
  , myProperty_1__(js_context.CreateObject())
  , myProperty_2__(js_context.CreateNumber()) {
}
```

Getter would be implemented like below. We are storing `JSValue` in C++ member, and this makes sense because we don't want to create new JSValue every time getter is called.

```c++
JSValue Widget::js_get_myProperty1() const HAL_NOEXCEPT {
  return myProperty_1__;
}

void Widget::JSExportInitialize() {
  JSExport<Widget>::AddValueProperty("myProperty1", std::mem_fn(&Widget::js_get_myProperty1)));
  JSExport<Widget>::AddValueProperty("myProperty2", std::mem_fn(&Widget::js_get_myProperty2)));
}
```

## Problem

The problem is, by this design, **we had to create *all* constants at proxy constructor**. Even when we don't use it at all.

```c++
class Widget : public JSExportObject, public JSExport<Widget> {
  private:
      JSValue myProperty_1__;
      JSValue myProperty_2__;

     // ...
     // what if we have 1,000 properties? Do we create *all* of them at constructor?
     // ...
      JSValue myProperty_1000__;
};
```

## Solution

Load properties on demand and cache the result if it's a read-only constant. That means **if constant is never used, no `JSValue` is created**. I introduced `JSExport<T>::AddConstantProperty` for the constant property instead of `JSExport<T>::AddValueProperty`. If you declare object property is constant, the "getter" callback will be called only once and the result is cached. This solution should be easy to implement for proxy developers, which should minimize transition cost to introduce cache mechanics.

```diff
-  JSExport<Widget>::AddValueProperty("myProperty1", std::mem_fn(&Widget::js_get_myProperty1));
+  JSExport<Widget>::AddConstantProperty("myProperty1", std::mem_fn(&Widget::js_get_myProperty1));
```

In this case getter would be like below, note that it's safe & efficient when you create new JSValue at getter, it's automatically cached and reused by HAL. In fact this getter is called only once when user uses this property for the first time. Again, this means **if this property is never used, no `JSValue` associated with this property is created**.

```c++
JSValue Widget::js_get_myProperty1() const HAL_NOEXCEPT {
  return get_context().CreateObject();
}
```