### PR TITLE
Implement LRU constant cache

### DIFF
--- a/examples/OtherWidget.cpp
+++ b/examples/OtherWidget.cpp
@@ -56,4 +56,36 @@ void OtherWidget::postCallAsConstructor(const JSContext& js_context, const std::
 void OtherWidget::JSExportInitialize() {
   JSExport<OtherWidget>::SetClassVersion(1);
   JSExport<OtherWidget>::SetParent(JSExport<JSExportObject>::Class());
+  JSExport<OtherWidget>::AddConstantProperty("CONST1", std::mem_fn(&OtherWidget::js_get_CONST1));
+  JSExport<OtherWidget>::AddConstantProperty("CONST2", std::mem_fn(&OtherWidget::js_get_CONST2));
+  JSExport<OtherWidget>::AddConstantProperty("CONST3", std::mem_fn(&OtherWidget::js_get_CONST3));
+  JSExport<OtherWidget>::AddConstantProperty("CONST4", std::mem_fn(&OtherWidget::js_get_CONST4));
+  JSExport<OtherWidget>::AddConstantProperty("CONST5", std::mem_fn(&OtherWidget::js_get_CONST5));
+  JSExport<OtherWidget>::AddConstantProperty("CONST6", std::mem_fn(&OtherWidget::js_get_CONST6));
+
 }
+
+JSValue OtherWidget::js_get_CONST1() HAL_NOEXCEPT {
+  return get_context().CreateNumber(1);
+}
+
+JSValue OtherWidget::js_get_CONST2() HAL_NOEXCEPT {
+  return get_context().CreateNumber(2);
+}
+
+JSValue OtherWidget::js_get_CONST3() HAL_NOEXCEPT {
+  return get_context().CreateNumber(3);
+}
+
+JSValue OtherWidget::js_get_CONST4() HAL_NOEXCEPT {
+  return get_context().CreateNumber(4);
+}
+
+JSValue OtherWidget::js_get_CONST5() HAL_NOEXCEPT {
+  return get_context().CreateNumber(5);
+}
+
+JSValue OtherWidget::js_get_CONST6() HAL_NOEXCEPT {
+  return get_context().CreateNumber(6);
+}
+

--- a/examples/OtherWidget.hpp
+++ b/examples/OtherWidget.hpp
@@ -61,6 +61,13 @@ public:
   virtual void postInitialize(JSObject& js_object) override;
   virtual void postCallAsConstructor(const JSContext& js_context, const std::vector<JSValue>& arguments) override;
 	
+  JSValue js_get_CONST1() HAL_NOEXCEPT;
+  JSValue js_get_CONST2() HAL_NOEXCEPT;
+  JSValue js_get_CONST3() HAL_NOEXCEPT;
+  JSValue js_get_CONST4() HAL_NOEXCEPT;
+  JSValue js_get_CONST5() HAL_NOEXCEPT;
+  JSValue js_get_CONST6() HAL_NOEXCEPT;
+
 private:
   
 };

--- a/include/HAL/JSExport.hpp
+++ b/include/HAL/JSExport.hpp
@@ -117,6 +117,12 @@ namespace HAL {
      */
     static detail::JSExportClass<T> Class();
     
+    /*
+     @method
+     @abstract Erase all constant cache
+     */
+    static void EvictAllCache();
+ 
     virtual ~JSExport() HAL_NOEXCEPT {
     }
     
@@ -623,6 +629,10 @@ namespace HAL {
     return js_export_class;
   }
   
+  template<typename T>
+  void JSExport<T>::EvictAllCache() {
+    detail::JSExportClass<T>::EvictAllCache();
+  }
 } // namespace HAL {
 
 #endif // _HAL_JSEXPORT_HPP_

--- a/test/JSExportTests.cpp
+++ b/test/JSExportTests.cpp
@@ -1413,7 +1413,7 @@ TEST_F(JSExportTests, LRUCache) {
   XCTAssertEqual("CONST4", keys.at(1));
 
   // evict all
-  HAL::detail::JSExportClass<OtherWidget>::EvictAllCache();
+  JSExport<OtherWidget>::EvictAllCache();
   keys = HAL::detail::JSExportClass<OtherWidget>::GetCachedKeys();
   XCTAssertTrue(keys.empty());
 }


### PR DESCRIPTION
[TIMOB-20316](https://jira.appcelerator.org/browse/TIMOB-20316)

Simple implementation for LRU cache for constant properties. This also provides some functions to evict cache explicitly, which might be useful when you want to clear caches when app is no longer active (i.e. at suspend event).

- `HAL::detail::JSExportClass<T>::EvictCache()`
- `HAL::detail::JSExportClass<T>::EvictAllCache()`
- `HAL::detail::JSExportClass<T>::ResizeCache(std::uint_t)`
- `HAL::detail::JSExportClass<T>::GetCachedKeys()`

And added shortcut for `EvictAllCache` from `JSExport<T>`

- `JSExport<T>::EvictAllCache()`