### PR TITLE
[TIMOB-23365] Allow boolean strings to be parsed correctly

### DIFF
--- a/src/JSValue.cpp
+++ b/src/JSValue.cpp
@@ -77,7 +77,11 @@ namespace HAL {
   
   JSValue::operator bool() const HAL_NOEXCEPT {
     HAL_JSVALUE_LOCK_GUARD;
-    return JSValueToBoolean(static_cast<JSContextRef>(js_context__), js_value_ref__);
+    const auto js_parse_ref__ = JSValueMakeFromJSONString(static_cast<JSContextRef>(js_context__), static_cast<JSStringRef>(operator JSString()));
+    if (!js_parse_ref__) {
+      return JSValueToBoolean(static_cast<JSContextRef>(js_context__), js_value_ref__);
+    }
+    return JSValueToBoolean(static_cast<JSContextRef>(js_context__), js_parse_ref__);
   }
   
   JSValue::operator double() const {


### PR DESCRIPTION
- Allow ``"true"`` and ``"false"`` strings to be parsed correctly when cast to a ``boolean``

###### TEST CASE
```Javascript
var win = Ti.UI.createWindow({ backgroundColor: 'white' }),
    btn = Ti.UI.createButton({
        backgroundColor: 'red',
        title: 'this should NOT be visible',
        visible: "false"
    });
win.add(btn);
win.open();
```

[JIRA Ticket](https://jira.appcelerator.org/browse/TIMOB-23365)