### PR TITLE
Introduce single context mode

### DIFF
--- a/src/JSContext.cpp
+++ b/src/JSContext.cpp
@@ -259,24 +259,30 @@ namespace HAL {
   
   JSContext::~JSContext() HAL_NOEXCEPT {
     HAL_LOG_TRACE("JSContext:: dtor ", this);
+#ifndef HAL_USE_SINGLE_CONTEXT
     HAL_LOG_TRACE("JSContext:: release ", js_global_context_ref__, " for ", this);
     JSGlobalContextRelease(js_global_context_ref__);
+#endif
   }
   
   JSContext::JSContext(const JSContext& rhs) HAL_NOEXCEPT
   : js_context_group__(rhs.js_context_group__)
   , js_global_context_ref__(rhs.js_global_context_ref__) {
     HAL_LOG_TRACE("JSContext:: copy ctor ", this);
+#ifndef HAL_USE_SINGLE_CONTEXT
     HAL_LOG_TRACE("JSContext:: retain ", js_global_context_ref__, " for ", this);
     JSGlobalContextRetain(js_global_context_ref__);
+#endif
   }
   
   JSContext::JSContext(JSContext&& rhs) HAL_NOEXCEPT
   : js_context_group__(std::move(rhs.js_context_group__))
   , js_global_context_ref__(rhs.js_global_context_ref__) {
     HAL_LOG_TRACE("JSContext:: move ctor ", this);
+#ifndef HAL_USE_SINGLE_CONTEXT
     HAL_LOG_TRACE("JSContext:: retain ", js_global_context_ref__, " for ", this);
     JSGlobalContextRetain(js_global_context_ref__);
+#endif
   }
   
   JSContext& JSContext::operator=(JSContext rhs) HAL_NOEXCEPT {
@@ -314,8 +320,10 @@ namespace HAL {
   , js_global_context_ref__(js_global_context_ref) {
     HAL_LOG_TRACE("JSContext:: ctor 2 ", this);
     assert(js_global_context_ref__);
+#ifndef HAL_USE_SINGLE_CONTEXT
     HAL_LOG_TRACE("JSContext:: retain ", js_global_context_ref__, " for ", this);
     JSGlobalContextRetain(js_global_context_ref__);
+#endif
   }
   
 } // namespace HAL {

--- a/src/JSContextGroup.cpp
+++ b/src/JSContextGroup.cpp
@@ -32,33 +32,41 @@ namespace HAL {
   : js_context_group_ref__(js_context_group_ref) {
     HAL_LOG_TRACE("JSContextGroup:: ctor 2 ", this);
     assert(js_context_group_ref__);
+#ifndef HAL_USE_SINGLE_CONTEXT
     HAL_LOG_TRACE("JSContextGroup:: retain ", js_context_group_ref__, " for ", this);
     JSContextGroupRetain(js_context_group_ref__);
     managed__ = true;
+#endif
   }
   
   JSContextGroup::~JSContextGroup() HAL_NOEXCEPT {
     HAL_LOG_TRACE("JSContextGroup:: dtor ", this);
+#ifndef HAL_USE_SINGLE_CONTEXT
     HAL_LOG_TRACE("JSContextGroup:: release ", js_context_group_ref__, " for ", this);
     if (managed__) {
       JSContextGroupRelease(js_context_group_ref__);
     }
+#endif
   }
   
   JSContextGroup::JSContextGroup(const JSContextGroup& rhs) HAL_NOEXCEPT
   : js_context_group_ref__(rhs.js_context_group_ref__) {
     HAL_LOG_TRACE("JSContextGroup:: copy ctor ", this);
+#ifndef HAL_USE_SINGLE_CONTEXT
     HAL_LOG_TRACE("JSContextGroup:: retain ", js_context_group_ref__, " for ", this);
     JSContextGroupRetain(js_context_group_ref__);
     managed__ = true;
+#endif
   }
   
   JSContextGroup::JSContextGroup(JSContextGroup&& rhs) HAL_NOEXCEPT
   : js_context_group_ref__(rhs.js_context_group_ref__) {
     HAL_LOG_TRACE("JSContextGroup:: move ctor ", this);
+#ifndef HAL_USE_SINGLE_CONTEXT
     HAL_LOG_TRACE("JSContextGroup:: retain ", js_context_group_ref__, " for ", this);
     JSContextGroupRetain(js_context_group_ref__);
     managed__ = true;
+#endif
   }
   
   JSContextGroup& JSContextGroup::operator=(JSContextGroup rhs) HAL_NOEXCEPT {


### PR DESCRIPTION
Introduce "single context mode", which basically disables retain/release for JS context and context group. This does _huge_ performance improvement especially on TitaniumKit, because only one context (global context) is actually used in TitaniumKit and there's no need to retain/release it.

In order to enable this, just define `HAL_USE_SINGLE_CONTEXT` before including `HAL.hpp`.
