### PR TITLE
Catch exception and save function name at function callback

### DIFF
--- a/include/HAL/detail/JSExportClass.hpp
+++ b/include/HAL/detail/JSExportClass.hpp
@@ -468,6 +468,14 @@ namespace HAL { namespace detail {
       JSObject js_object(JSObject::FindJSObject(context_ref, function_ref));
       *exception = static_cast<JSValueRef>(CreateJSError("CallNamedFunction", function_name, js_object, e));
       return nullptr;
+    } catch (const std::exception& e) {
+      JSObject js_object(JSObject::FindJSObject(context_ref, function_ref));
+      *exception = static_cast<JSValueRef>(CreateJSError("CallNamedFunction", js_object, function_name + ": " + e.what()));
+      return nullptr;
+    } catch (...) {
+      JSObject js_object(JSObject::FindJSObject(context_ref, function_ref));
+      *exception = static_cast<JSValueRef>(CreateJSError("CallNamedFunction", js_object, function_name + ": " + "unknown exception"));
+      return nullptr;
     }
 
   } catch (const std::exception& e) {


### PR DESCRIPTION
Related to [TIMOB-23621](https://jira.appcelerator.org/browse/TIMOB-23621)

When proxy function throws c++ exception, HAL should catch it and update `*exception` to `JSError` with function name. This should help to provide better log message.