### PR TITLE
Keep the callback valid after the destruction of rhs in JSFunction co…

### DIFF
--- a/include/HAL/JSFunction.hpp
+++ b/include/HAL/JSFunction.hpp
@@ -35,7 +35,10 @@ public:
     static void UnRegisterJSFunctionCallback(JSObjectRef js_object_ref);
     static JSFunctionCallback FindJSFunctionCallback(JSObjectRef js_object_ref);
 
-    JSFunction& operator=(const JSFunction &rhs);
+    JSFunction(const JSFunction& rhs);
+    JSFunction(JSFunction&& rhs);
+    JSFunction& operator=(const JSFunction& rhs);
+    JSFunction& operator=(JSFunction&& rhs);
 
     virtual ~JSFunction() HAL_NOEXCEPT;
 
@@ -51,6 +54,8 @@ private:
 
     static JSValueRef  JSObjectCallAsFunctionCallback(JSContextRef context_ref, JSObjectRef function_ref, JSObjectRef this_object_ref, size_t argument_count, const JSValueRef arguments_array[], JSValueRef* exception);
     static JSObjectRef MakeFunction(const JSContext& js_context, const JSString& function_name, const JSFunctionCallback& callback);
+
+    void RetainCallbackAfterCopy();
 
     // Silence 4251 on Windows since private member variables do not
     // need to be exported from a DLL.

--- a/include/HAL/JSFunction.hpp
+++ b/include/HAL/JSFunction.hpp
@@ -35,6 +35,8 @@ public:
     static void UnRegisterJSFunctionCallback(JSObjectRef js_object_ref);
     static JSFunctionCallback FindJSFunctionCallback(JSObjectRef js_object_ref);
 
+    JSFunction& operator=(const JSFunction &rhs);
+
     virtual ~JSFunction() HAL_NOEXCEPT;
 
 private:

--- a/src/JSFunction.cpp
+++ b/src/JSFunction.cpp
@@ -26,6 +26,42 @@ JSFunction::JSFunction(const JSContext& js_context, const JSString& function_nam
         : JSObject(js_context, MakeFunction(js_context, function_name, callback)) {
 }
 
+JSFunction::JSFunction(const JSFunction& rhs) : JSObject(rhs) {
+    RetainCallbackAfterCopy();
+}
+
+JSFunction::JSFunction(JSFunction&& rhs) : JSObject(std::move(rhs)) {
+    RetainCallbackAfterCopy();
+}
+
+JSFunction& JSFunction::operator=(const JSFunction& rhs) {
+    JSObject::operator=(rhs);
+    RetainCallbackAfterCopy();
+    return *this;
+}
+
+JSFunction& JSFunction::operator=(JSFunction&& rhs) {
+    JSObject::operator=(std::move(rhs));
+    RetainCallbackAfterCopy();
+    return *this;
+}
+
+/**
+ * To keep the callback valid after the destruction of rhs,
+ * we must obtain a new JSObjectRef and register the callback with it.
+ * The rhs will unregister the callback with the original js_object_ref__ in destructor.
+ */
+void JSFunction::RetainCallbackAfterCopy() {
+    const auto &callback = FindJSFunctionCallback(js_object_ref__);
+    if (callback) {
+        JSValue name(js_context__, JSObjectGetProperty(static_cast<JSContextRef>(js_context__), js_object_ref__, static_cast<JSStringRef>(JSString("name")), nullptr));
+        std::string name_string = static_cast<std::string>(name);
+        UnRegisterJSContext(js_object_ref__);
+        js_object_ref__ = MakeFunction(js_context__, static_cast<JSString>(name), callback);
+        JSFunction::RegisterJSFunctionCallback(js_object_ref__, callback);
+    }
+}
+
 JSObjectRef JSFunction::MakeFunction(const JSContext& js_context, const JSString& body, const std::vector<JSString>& parameter_names, const JSString& func_name, const JSString& source_url, int starting_line_number) {
 
     JSString function_name = func_name;
@@ -110,24 +146,6 @@ JSObjectRef JSFunction::MakeFunction(const JSContext& js_context, const JSString
     JSObjectRef js_object_ref = JSObjectMakeFunctionWithCallback(static_cast<JSContextRef>(js_context), static_cast<JSStringRef>(function_name), JSFunction::JSObjectCallAsFunctionCallback);
     JSFunction::RegisterJSFunctionCallback(js_object_ref, callback);
     return js_object_ref;
-}
-
-/**
- * To keep the callback valid after the destruction of rhs,
- * we must obtain a new JSObjectRef and register the callback with it.
- * The rhs will unregister the callback with the original js_object_ref__ in destructor.
- */
-JSFunction& JSFunction::operator=(const JSFunction &rhs) {
-    JSObject::operator=(rhs);
-    const auto &callback = FindJSFunctionCallback(js_object_ref__);
-    if (callback) {
-        JSValue name(js_context__, JSObjectGetProperty(static_cast<JSContextRef>(js_context__), js_object_ref__, static_cast<JSStringRef>(JSString("name")), nullptr));
-        std::string name_string = static_cast<std::string>(name);
-        UnRegisterJSContext(js_object_ref__);
-        js_object_ref__ = MakeFunction(js_context__, static_cast<JSString>(name), callback);
-        JSFunction::RegisterJSFunctionCallback(js_object_ref__, callback);
-    }
-    return *this;
 }
 
 JSFunction::~JSFunction() HAL_NOEXCEPT {

--- a/test/JSObjectTests.cpp
+++ b/test/JSObjectTests.cpp
@@ -514,7 +514,17 @@ TEST_F(JSObjectTests, JSFunctionCallback) {
   // testing NOOP function
   JSFunction noop_function = js_context.CreateFunction();
   XCTAssertTrue(noop_function(noop_function).IsUndefined());
-  
+
+  // test callback validity after copy source has destructed
+  JSFunction js_copy_function = js_context.CreateFunction();
+  {
+     JSFunction js_src_function = js_context.CreateFunction(callback);
+     js_copy_function = js_src_function;
+  }
+
+  // now js_src_function has destructed
+  global_object.SetProperty("testJSFunctionCallbackCopy", js_copy_function);
+  XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallbackCopy('JavaScript');")));
 }
 
 TEST_F(JSObjectTests, JSON_stringify) {

--- a/test/JSObjectTests.cpp
+++ b/test/JSObjectTests.cpp
@@ -499,32 +499,70 @@ TEST_F(JSObjectTests, JSFunctionCallback) {
     return js_context.CreateString("Hello, "+static_cast<std::string>(arguments.at(0)));
   };
 
-  JSFunction js_function = js_context.CreateFunction(callback);
-
-  XCTAssertTrue(js_function.IsFunction());
-  XCTAssertEqual("Hello, world", static_cast<std::string>(js_function("world", js_function)));
-  XCTAssertFalse(js_function.IsArray());
-  XCTAssertFalse(js_function.IsError());
-  
   auto global_object = js_context.get_global_object();
-  global_object.SetProperty("testJSFunctionCallback", js_function);
+
+  {
+    JSFunction js_function = js_context.CreateFunction(callback);
+
+    XCTAssertTrue(js_function.IsFunction());
+    XCTAssertEqual("Hello, world", static_cast<std::string>(js_function("world", js_function)));
+    XCTAssertFalse(js_function.IsArray());
+    XCTAssertFalse(js_function.IsError());
+
+    global_object.SetProperty("testJSFunctionCallback", js_function);
+
+    XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
+    global_object.DeleteProperty("testJSFunctionCallback");
+  }
+
+  // test callback validity after copy source has destructed
+  // copy assignment
+  {
+    JSFunction js_function_copy_assigned = js_context.CreateFunction();
+    {
+      JSFunction js_src_function = js_context.CreateFunction(callback);
+      js_function_copy_assigned = js_src_function;
+    }
+
+    // now js_src_function has destructed
+    global_object.SetProperty("testJSFunctionCallback", js_function_copy_assigned);
+    XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
+    global_object.DeleteProperty("testJSFunctionCallback");
+  }
+
+  // move assignment
+  {
+    JSFunction js_function_move_assigned = js_context.CreateFunction();
   
-  XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
+    js_function_move_assigned = std::move(js_context.CreateFunction(callback));
+
+    global_object.SetProperty("testJSFunctionCallback", js_function_move_assigned);
+    XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
+    global_object.DeleteProperty("testJSFunctionCallback");
+  }
+
+  // copy construction
+  {
+    JSFunction js_src_function = js_context.CreateFunction(callback);
+    JSFunction js_function_copy_constructed(js_src_function);
+
+    global_object.SetProperty("testJSFunctionCallback", js_function_copy_constructed);
+    XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
+    global_object.DeleteProperty("testJSFunctionCallback");
+  }
+
+  // move construction
+  {
+    JSFunction js_function_move_constructed = std::move(js_context.CreateFunction(callback));
+
+    global_object.SetProperty("testJSFunctionCallback", js_function_move_constructed);
+    XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallback('JavaScript');")));
+    global_object.DeleteProperty("testJSFunctionCallback");
+  }
 
   // testing NOOP function
   JSFunction noop_function = js_context.CreateFunction();
   XCTAssertTrue(noop_function(noop_function).IsUndefined());
-
-  // test callback validity after copy source has destructed
-  JSFunction js_copy_function = js_context.CreateFunction();
-  {
-     JSFunction js_src_function = js_context.CreateFunction(callback);
-     js_copy_function = js_src_function;
-  }
-
-  // now js_src_function has destructed
-  global_object.SetProperty("testJSFunctionCallbackCopy", js_copy_function);
-  XCTAssertEqual("Hello, JavaScript", static_cast<std::string>(js_context.JSEvaluateScript("testJSFunctionCallbackCopy('JavaScript');")));
 }
 
 TEST_F(JSObjectTests, JSON_stringify) {


### PR DESCRIPTION
To keep the callback valid after the destruction of rhs, we must obtain a new JSObjectRef and register the callback with it.
The rhs will unregister the callback with the original js_object_ref__ in destructor.