### PR TITLE
HAL Issues#70 `JSValue::ToJSONString()` should be `const`

### DIFF
--- a/include/HAL/JSValue.hpp
+++ b/include/HAL/JSValue.hpp
@@ -89,7 +89,7 @@ namespace HAL {
      @result A JSString containing the JSON serialized representation
      of this JavaScript value.
      */
-    virtual JSString ToJSONString(unsigned indent = 0) final;
+    virtual JSString ToJSONString(unsigned indent = 0) const final;
     
     /*!
      @method

--- a/src/JSValue.cpp
+++ b/src/JSValue.cpp
@@ -60,7 +60,7 @@ namespace HAL {
     }
   }
 
-  JSString JSValue::ToJSONString(unsigned indent) {
+  JSString JSValue::ToJSONString(unsigned indent) const {
     HAL_JSVALUE_LOCK_GUARD;
     JSValueRef exception { nullptr };
     JSStringRef js_string_ref = JSValueCreateJSONString(static_cast<JSContextRef>(js_context__), js_value_ref__, indent, &exception);


### PR DESCRIPTION
Follow up on https://github.com/appcelerator/HAL/issues/70

Annotate `JSValue::ToJSONString()` as a `const` just like `JSValue::JString()`