### PR TITLE
enumerable property is not passed to JSExport

### DIFF
--- a/examples/Widget.cpp
+++ b/examples/Widget.cpp
@@ -210,6 +210,7 @@ void Widget::JSExportInitialize() {
   JSExport<Widget>::AddValueProperty("name"       , std::mem_fn(&Widget::js_get_name)  , std::mem_fn(&Widget::js_set_name));
   JSExport<Widget>::AddValueProperty("number"     , std::mem_fn(&Widget::js_get_number), std::mem_fn(&Widget::js_set_number));
   JSExport<Widget>::AddValueProperty("value"     , std::mem_fn(&Widget::js_get_value), std::mem_fn(&Widget::js_set_value));
+  JSExport<Widget>::AddValueProperty("noenumerable_value", std::mem_fn(&Widget::js_get_noenumerable_value), nullptr, false);
   JSExport<Widget>::AddConstantProperty("pi"     , std::mem_fn(&Widget::js_get_pi));
   JSExport<Widget>::AddFunctionProperty("helloCallback", std::mem_fn(&Widget::js_helloLambda));
   JSExport<Widget>::AddFunctionProperty("sayHello", std::mem_fn(&Widget::js_sayHello));
@@ -262,6 +263,10 @@ JSValue Widget::js_get_value() const HAL_NOEXCEPT {
 bool Widget::js_set_value(const JSValue& value) HAL_NOEXCEPT {
   jsvalue__ = value;
   return true;
+}
+
+JSValue Widget::js_get_noenumerable_value() const HAL_NOEXCEPT {
+  return get_context().CreateBoolean(true);
 }
 
 JSValue Widget::js_get_pi() HAL_NOEXCEPT {

--- a/examples/Widget.hpp
+++ b/examples/Widget.hpp
@@ -89,6 +89,8 @@ public:
   // Remove "const" to test lazy loading
   JSValue js_get_pi() HAL_NOEXCEPT;
   
+  JSValue js_get_noenumerable_value() const HAL_NOEXCEPT;
+
   JSValue js_get_value() const                HAL_NOEXCEPT;
   bool    js_set_value(const JSValue& value) HAL_NOEXCEPT;
   

--- a/include/HAL/JSExport.hpp
+++ b/include/HAL/JSExport.hpp
@@ -564,7 +564,7 @@ namespace HAL {
   
   template<typename T>
   void JSExport<T>::AddValueProperty(const JSString& property_name, detail::GetNamedValuePropertyCallback<T> get_callback, detail::SetNamedValuePropertyCallback<T> set_callback, bool enumerable) {
-    builder__.AddValueProperty(property_name, get_callback, set_callback);
+    builder__.AddValueProperty(property_name, get_callback, set_callback, enumerable);
   }
 
   template<typename T>

--- a/test/JSExportTests.cpp
+++ b/test/JSExportTests.cpp
@@ -155,6 +155,12 @@ TEST_F(JSExportTests, JSExport) {
   XCTAssertEqual(3.141592653589793, static_cast<double>(result));
   XCTAssertEqual(1, widget_ptr->get_count_for_pi());
 
+  // test non-enumerable property
+  result = js_context.JSEvaluateScript("widget.noenumerable_value;");
+  XCTAssertTrue(static_cast<bool>(result));
+  result = js_context.JSEvaluateScript("Object.keys(widget).indexOf('noenumerable_value')===-1;");
+  XCTAssertTrue(static_cast<bool>(result));
+
   // FIXME
   auto string_ptr = widget.GetPrivate<std::string>();
   //XCTAssertEqual(nullptr, string_ptr);


### PR DESCRIPTION
When you want to set `enumerable=false` to the property on your `JSExport` class, it is not actually passed to `JSExport`. That makes it impossible to define non-enumerable property.
